### PR TITLE
Build APKs in GHA and upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,23 @@ jobs:
         uses: android-actions/setup-android@v3
         with:
           packages: |
-            "platforms;android-35" \
-            "build-tools;35.0.0"
+            platforms;android-35 build-tools;35.0.0
+      - name: Install Gradle (official distribution)
+        env:
+          GRADLE_VERSION: "8.13"
+        run: |
+          curl -L -o gradle-${GRADLE_VERSION}-bin.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+          unzip -q gradle-${GRADLE_VERSION}-bin.zip -d "$HOME/gradle"
+          echo "$HOME/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+          gradle --version
 
       - name: Build with Gradle
-        run: ./gradlew --no-daemon build
+        run: gradle --no-daemon build
 
+      - name: Upload APKs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: apk-${{ github.run_number }}
+          path: "**/build/outputs/apk/**/*.apk"
+          retention-days: 7

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
 
     defaultConfig {
         applicationId = "org.osservatorionessuno.bugbane"
-        minSdk = 26
-        targetSdk = 35
+        minSdk = 29
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
This seems now to be working:
 - Updated minSdk to 29 to match out API usage
 - Set-up Gradle 8.13, we will need to bump in the future
 - Build are successful and artifacts are uploaded