### PR TITLE
Stub implementation of QF modules

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/Module.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/Module.kt
@@ -1,0 +1,26 @@
+package org.osservatorionessuno.bugbane.qf
+
+import android.content.Context
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import java.io.File
+
+/**
+ * Basic contract for a Quick Forensics module.
+ *
+ * Implementations may interact with the device through the provided
+ * [AbsAdbConnectionManager] or by using Android platform APIs via [Context].
+ * All generated artifacts should be written inside [outDir].
+ */
+interface Module {
+    /** Name used for logging or debugging. */
+    val name: String
+
+    /**
+     * Execute the module.
+     *
+     * @param context Application context.
+     * @param manager Active ADB connection manager for low-level operations.
+     * @param outDir Directory where module output should be written.
+     */
+    fun run(context: Context, manager: AbsAdbConnectionManager, outDir: File)
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/QuickForensics.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/QuickForensics.kt
@@ -1,0 +1,71 @@
+package org.osservatorionessuno.bugbane.qf
+
+import android.util.Log
+import android.content.Context
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import java.io.File
+import java.io.IOException
+import java.util.UUID
+import org.osservatorionessuno.bugbane.qf.modules.Dumpsys
+import org.osservatorionessuno.bugbane.qf.modules.Logcat
+import org.osservatorionessuno.bugbane.qf.modules.Env
+
+private const val TAG = "QuickForensics"
+
+/**
+ * Entry point used by the UI layer to trigger an AndroidQF-compatible dump.
+ *
+ * The class wires the ADB connection with a collection of [Module] instances
+ * responsible for generating each file inside the resulting acquisition
+ * directory.
+ *
+ * At this stage only the scaffolding is provided – concrete modules still need
+ * to be implemented.
+ */
+ class QuickForensics(
+     private val modules: List<Module> = listOf(
+         Env(),
+         Dumpsys(),
+         Logcat(),
+     )
+ ) {
+
+    /**
+     * Run all registered modules and store their output inside a newly created
+     * acquisition directory located under [baseOutputDir].
+     *
+     * @param context Application context.
+     * @param manager Active ADB connection manager.
+     * @param baseOutputDir Directory where the acquisition folder will be created.
+     * @return The directory containing the acquisition results.
+     */
+    @Throws(IOException::class)
+    fun run(
+        context: Context,
+        manager: AbsAdbConnectionManager,
+        baseOutputDir: File
+    ): File {
+        if (!baseOutputDir.exists() && !baseOutputDir.mkdirs()) {
+            throw IOException("Unable to create base output directory: $baseOutputDir")
+        }
+
+        val acquisitionDir = File(baseOutputDir, UUID.randomUUID().toString())
+        if (!acquisitionDir.mkdirs()) {
+            throw IOException("Unable to create acquisition directory: $acquisitionDir")
+        }
+        Log.i(TAG, "Starting acquisition in ${acquisitionDir.absolutePath}")
+
+        modules.forEach { module ->
+            Log.i(TAG, "Running module ${module.name}")
+            try {
+                module.run(context, manager, acquisitionDir)
+                Log.i(TAG, "Module ${module.name} finished")
+            } catch (t: Throwable) {
+                Log.e(TAG, "Module ${module.name} failed", t)
+            }
+        }
+
+        Log.i(TAG, "Acquisition complete in ${acquisitionDir.absolutePath}")
+        return acquisitionDir
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/Shell.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/Shell.kt
@@ -1,0 +1,70 @@
+package org.osservatorionessuno.bugbane.qf
+
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import io.github.muntashirakon.adb.AdbStream
+import io.github.muntashirakon.adb.LocalServices
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+
+/**
+ * Small wrapper around [AbsAdbConnectionManager] that executes shell commands
+ * and returns their standard output.
+ */
+class Shell(private val manager: AbsAdbConnectionManager) {
+
+    /**
+     * Execute [command] via the ADB shell service and return its output.
+     *
+     * The implementation is intentionally simple and meant for background
+     * operations. Errors are propagated to the caller.
+     */
+    @Throws(IOException::class)
+    fun exec(command: String): String {
+        val stream: AdbStream = manager.openStream(LocalServices.SHELL)
+        stream.use { s ->
+            s.openOutputStream().use { os ->
+                os.write((command + "\n").toByteArray(StandardCharsets.UTF_8))
+                os.flush()
+            }
+            val sb = StringBuilder()
+            BufferedReader(InputStreamReader(s.openInputStream())).use { reader ->
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    sb.appendLine(line)
+                }
+            }
+            return sb.toString()
+        }
+    }
+
+    /**
+     * Execute [command] and stream the resulting standard output directly into
+     * [file].
+     *
+     * This method is intended for commands that may produce large outputs, such
+     * as `dumpsys` or `logcat`, to avoid keeping the entire response in memory.
+     */
+    @Throws(IOException::class)
+    fun execToFile(command: String, file: File) {
+        val stream: AdbStream = manager.openStream(LocalServices.SHELL)
+        stream.use { s ->
+            s.openOutputStream().use { os ->
+                os.write((command + "\n").toByteArray(StandardCharsets.UTF_8))
+                os.flush()
+            }
+            s.openInputStream().use { input ->
+                FileOutputStream(file).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    var read: Int
+                    while (input.read(buffer).also { read = it } != -1) {
+                        output.write(buffer, 0, read)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/Shell.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/Shell.kt
@@ -2,67 +2,53 @@ package org.osservatorionessuno.bugbane.qf
 
 import io.github.muntashirakon.adb.AbsAdbConnectionManager
 import io.github.muntashirakon.adb.AdbStream
-import io.github.muntashirakon.adb.LocalServices
-import java.io.BufferedReader
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.io.InputStreamReader
-import java.nio.charset.StandardCharsets
 
-/**
- * Small wrapper around [AbsAdbConnectionManager] that executes shell commands
- * and returns their standard output.
- */
 class Shell(private val manager: AbsAdbConnectionManager) {
 
-    /**
-     * Execute [command] via the ADB shell service and return its output.
-     *
-     * The implementation is intentionally simple and meant for background
-     * operations. Errors are propagated to the caller.
-     */
+    // Try exec: first (no PTY, cleaner), fall back to shell:
     @Throws(IOException::class)
-    fun exec(command: String): String {
-        val stream: AdbStream = manager.openStream(LocalServices.SHELL)
-        stream.use { s ->
-            s.openOutputStream().use { os ->
-                os.write((command + "\n").toByteArray(StandardCharsets.UTF_8))
-                os.flush()
-            }
-            val sb = StringBuilder()
-            BufferedReader(InputStreamReader(s.openInputStream())).use { reader ->
-                var line: String?
-                while (reader.readLine().also { line = it } != null) {
-                    sb.appendLine(line)
-                }
-            }
-            return sb.toString()
+    private fun openCommandStream(command: String): AdbStream {
+        return try {
+            manager.openStream("exec:$command")
+        } catch (e: IOException) {
+            // Older/newer mismatches or vendor builds may lack exec:
+            manager.openStream("shell:$command")
         }
     }
 
-    /**
-     * Execute [command] and stream the resulting standard output directly into
-     * [file].
-     *
-     * This method is intended for commands that may produce large outputs, such
-     * as `dumpsys` or `logcat`, to avoid keeping the entire response in memory.
-     */
+    /** Run a command and return its entire stdout as UTF-8 text. */
+    @Throws(IOException::class)
+    fun exec(command: String): String {
+        openCommandStream(command).use { s ->
+            s.openInputStream().use { input ->
+                return input.readBytes().toString(Charsets.UTF_8)
+            }
+        }
+    }
+
+    /** Run a command and stream stdout to a file (good for big outputs). */
     @Throws(IOException::class)
     fun execToFile(command: String, file: File) {
-        val stream: AdbStream = manager.openStream(LocalServices.SHELL)
-        stream.use { s ->
-            s.openOutputStream().use { os ->
-                os.write((command + "\n").toByteArray(StandardCharsets.UTF_8))
-                os.flush()
-            }
+        openCommandStream(command).use { s ->
             s.openInputStream().use { input ->
+                file.parentFile?.mkdirs()
                 FileOutputStream(file).use { output ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    var read: Int
-                    while (input.read(buffer).also { read = it } != -1) {
-                        output.write(buffer, 0, read)
+                    val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val n = try {
+                            input.read(buf)
+                        } catch (e: IOException) {
+                            // Many devices throw "Stream closed" at logical EOF. If we've written
+                            // something already, treat it as success; otherwise rethrow.
+                            if (file.length() > 0L) break else throw e
+                        }
+                        if (n == -1) break
+                        output.write(buf, 0, n)
                     }
+                    output.flush()
                 }
             }
         }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Dumpsys.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Dumpsys.kt
@@ -1,0 +1,19 @@
+package org.osservatorionessuno.bugbane.qf.modules
+
+import android.content.Context
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import org.osservatorionessuno.bugbane.qf.Module
+import org.osservatorionessuno.bugbane.qf.Shell
+import java.io.File
+
+/**
+ * Sample module that runs `dumpsys` and stores the output.
+ */
+class Dumpsys : Module {
+    override val name: String = "dumpsys"
+
+    override fun run(context: Context, manager: AbsAdbConnectionManager, outDir: File) {
+        val shell = Shell(manager)
+        shell.execToFile("dumpsys", File(outDir, "dumpsys.txt"))
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Env.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Env.kt
@@ -1,0 +1,19 @@
+package org.osservatorionessuno.bugbane.qf.modules
+
+import android.content.Context
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import org.osservatorionessuno.bugbane.qf.Module
+import org.osservatorionessuno.bugbane.qf.Shell
+import java.io.File
+
+/**
+ * Sample module that captures the shell environment variables using `env`.
+ */
+class Env : Module {
+    override val name: String = "env"
+
+    override fun run(context: Context, manager: AbsAdbConnectionManager, outDir: File) {
+        val shell = Shell(manager)
+        shell.execToFile("env", File(outDir, "env.txt"))
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Logcat.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/qf/modules/Logcat.kt
@@ -1,0 +1,24 @@
+package org.osservatorionessuno.bugbane.qf.modules
+
+import android.content.Context
+import io.github.muntashirakon.adb.AbsAdbConnectionManager
+import org.osservatorionessuno.bugbane.qf.Module
+import org.osservatorionessuno.bugbane.qf.Shell
+import java.io.File
+
+/**
+ * Sample module that collects logcat output.
+ */
+class Logcat : Module {
+    override val name: String = "logcat"
+
+    override fun run(context: Context, manager: AbsAdbConnectionManager, outDir: File) {
+        val shell = Shell(manager)
+        shell.execToFile("logcat -d -b all \"*:V\"", File(outDir, "logcat.txt"))
+        try {
+            shell.execToFile("logcat -L -b all \"*:V\"", File(outDir, "logcat_old.txt"))
+        } catch (_: Throwable) {
+            // best-effort
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.launch
 import org.osservatorionessuno.bugbane.R
 import org.osservatorionessuno.bugbane.utils.ConfigurationManager
 import org.osservatorionessuno.bugbane.SlideshowActivity
+import java.io.File
 
 data class ChecklistItem(
     val id: Int,
@@ -190,8 +191,9 @@ fun ScanScreen(
 
                 if (!isScanning) {
                     coroutineScope.launch {
-                        viewModel.execute("id")
-                        
+                        val baseDir = File(context.filesDir, "acquisitions")
+                        viewModel.runQuickForensics(baseDir)
+
                         isScanning = true
                         // Reset all items to unchecked
                         checklistItems = checklistItems.map { it.copy(isChecked = false) }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbViewModel.java
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbViewModel.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -231,17 +232,13 @@ public class AdbViewModel extends AndroidViewModel {
         });
     }
 
-    public void runQuickForensics() {
+    public void runQuickForensics(@NonNull File baseDir) {
         executor.submit(() -> {
             try {
                 AbsAdbConnectionManager manager = AdbConnectionManager.getInstance(getApplication());
-                // TODO: Implement QuickForensics functionality
-                // new org.osservatorionessuno.bugbane.qf.QuickForensics()
-                //         .run(getApplication(), manager);
-                System.out.println("QuickForensics functionality not yet implemented");
-                // Post message to main thread via LiveData instead of Toast
-                commandOutput.postValue("QuickForensics functionality not yet implemented");
-            } catch (Exception e) {
+                File out = new org.osservatorionessuno.bugbane.qf.QuickForensics()
+                        .run(getApplication(), manager, baseDir);
+                commandOutput.postValue("QuickForensics completed: " + out.getAbsolutePath());            } catch (Exception e) {
                 e.printStackTrace();
                 commandOutput.postValue("Error running QuickForensics: " + e.getMessage());
             }


### PR DESCRIPTION
This PR introduce a class, QuickForensics, that can run different modules in a similar way as AndroidQF. There's a lot more to do, but it helped me understand a few quirks:
 - `shell:` is interactive and spawns a pty. When you execute a command in this format, you do not really know when it terminates.
 - `shell:command` should be usable to execute a command and exit on termination.
 - `exec:` should be usable to execute a command and properly catch stderr/stdout.

For some reason, libadb-android does not list `exec:` in services but it is probably the most useful for us. Sadly, there are known problems of the stdout/err stream being closed early when receiving large outputs (such as the output of `dumpsys`). An hacky workaround here is to catch the exception and ignore it if there's still data in output. Will need more scrutiny and modules before merging. We should also generate per-acquisition metadata.