### PR TITLE
FDroid metadata and CI

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -1,0 +1,220 @@
+name: F-Droid
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  TZ: UTC
+  LANG: C.UTF-8
+  LC_ALL: C.UTF-8
+  serverwebroot: /tmp
+  APPID: org.osservatorionessuno.bugbane
+  FDROID_BUILD: "1"
+
+jobs:
+  fdroid-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Stable env
+        run: |
+          echo "TZ=UTC" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> $GITHUB_ENV
+          echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl locales \
+            python3 python3-pip python3-launchpadlib \
+            openjdk-17-jdk-headless apksigner mercurial \
+            jq unzip diffutils rsync
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platforms;android-36 build-tools;36.0.0
+
+      - name: Install Gradle
+        env:
+          GRADLE_VERSION: "8.13"
+        run: |
+          curl -L -o gradle-${GRADLE_VERSION}-bin.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+          unzip -q gradle-${GRADLE_VERSION}-bin.zip -d "$HOME/gradle"
+          echo "$HOME/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+          gradle --version
+
+      - name: Add fdroidserver to PATH/ENV
+        run: |
+          git clone --depth 1 https://gitlab.com/fdroid/fdroidserver.git fdroidserver
+          cd fdroidserver
+          pip install --upgrade pip setuptools wheel
+          pip install .
+          cd ..
+          chmod +x fdroidserver/fdroid
+          echo "$GITHUB_WORKSPACE/fdroidserver" >> "$GITHUB_PATH"
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/fdroidserver:$GITHUB_WORKSPACE/fdroidserver/examples" >> "$GITHUB_ENV"
+
+      - name: Check fdroid version
+        run: fdroid --version
+
+      - name: Determine APPID
+        run: |
+          if [ "${APPID}" = "org.example.app" ]; then
+            APPID=$(ls metadata/*.yml | head -n1 | sed -E 's|metadata/(.*)\.yml|\1|')
+          fi
+          echo "APPID=$APPID" >> $GITHUB_ENV
+          echo "Using APPID=$APPID"
+
+      - name: Prepare full fdroiddata
+        run: |
+          set -euo pipefail
+          TMP_META_DIR="$(mktemp -d)"
+          echo "TMP_META_DIR=$TMP_META_DIR" >> $GITHUB_ENV
+          echo "Using temp repo: $TMP_META_DIR"
+          mkdir -p "$serverwebroot/repo/status"
+
+          # Clone upstream fdroiddata (includes config/, icons, etc.)
+          git clone --depth 1 https://gitlab.com/fdroid/fdroiddata.git "$TMP_META_DIR"
+
+          # Overwrite our app's metadata file into that clone
+          test -f "metadata/${APPID}.yml" || { echo "::error::metadata/${APPID}.yml not found"; exit 1; }
+          cp "metadata/${APPID}.yml" "$TMP_META_DIR/metadata/${APPID}.yml"
+
+          cd "$TMP_META_DIR"
+          cat > config.yml <<'YAML'
+          repo_url: https://example.invalid/repo
+          make_current_version_link: false
+          gradle: gradle
+          cachedir: /tmp/.cache/fdroid
+          gradle_version_dir: /home/runner/.gradle/wrapper/dists
+          YAML
+          chmod 600 config.yml
+
+          # Commit so the repo is clean
+          git -C "$TMP_META_DIR" add "metadata/${APPID}.yml"
+          git -C "$TMP_META_DIR" add "config.yml"
+          git -C "$TMP_META_DIR" config user.email "ci@example.invalid"
+          git -C "$TMP_META_DIR" config user.name  "CI"
+          git -C "$TMP_META_DIR" commit -m "Use custom metadata for ${APPID}" >/dev/null
+
+      - name: Pin metadata commit in temp repo
+        run: |
+          set -euo pipefail
+          TMP_META_DIR="${TMP_META_DIR:?}"
+          APPFILE="$TMP_META_DIR/metadata/${APPID}.yml"
+
+          # Pin to latest tag if available, else to HEAD of our source repo
+          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+            PIN=$(git describe --tags --abbrev=0)
+          else
+            PIN=$(git rev-parse HEAD)
+          fi
+          echo "Using PIN=$PIN"
+          # Replace only the first 'commit:' occurrence
+          sed -i -E "0,/^(\s*commit:\s*).*/s//\1$PIN/" "$APPFILE"
+
+          git -C "$TMP_META_DIR" add "$APPFILE"
+          git -C "$TMP_META_DIR" commit -m "Pin commit to $PIN" >/dev/null
+          echo "PIN=$PIN" >> $GITHUB_ENV
+
+      - name: F-Droid checkupdates
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid checkupdates --auto -v "$APPID"
+
+      - name: F-Droid rewritemeta + lint
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid rewritemeta "$APPID"
+          fdroid lint "$APPID"
+
+      - name: Build
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid build --verbose --no-tarball "$APPID"
+
+      - name: Restore combined keystore (APK + repo)
+        env:
+          APK_KEYSTORE_B64: ${{ secrets.APK_KEYSTORE_B64 }}
+        run: |
+          set -euo pipefail
+          echo "$APK_KEYSTORE_B64" | base64 -d > ci-two-keys.jks
+          chmod 600 ci-two-keys.jks
+          echo "CI_KEYSTORE=$GITHUB_WORKSPACE/ci-two-keys.jks" >> $GITHUB_ENV
+          ls -lh "$GITHUB_WORKSPACE/ci-two-keys.jks"
+          sha256sum "$GITHUB_WORKSPACE/ci-two-keys.jks"
+
+      - name: Append signing config to config.yml
+        env:
+          APK_KEYSTORE_PASSWORD: ${{ secrets.APK_KEYSTORE_PASSWORD }}
+          APK_KEY_ALIAS:         ${{ secrets.APK_KEY_ALIAS }}
+          APK_KEY_PASSWORD:      ${{ secrets.APK_KEY_PASSWORD }}
+          REPO_KEY_ALIAS:        ${{ secrets.REPO_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          {
+            echo "keystore: \"$CI_KEYSTORE\""
+            echo "keystorepass: \"$APK_KEYSTORE_PASSWORD\""
+            echo "keyalias: \"$APK_KEY_ALIAS\""
+            echo "keypass: \"$APK_KEY_PASSWORD\""
+            echo "repo_keyalias: \"$REPO_KEY_ALIAS\""
+            echo "keyaliases:"
+            echo "  ${APPID}: \"$APK_KEY_ALIAS\""
+          } >> config.yml
+          chmod 600 config.yml
+
+      - name: Publish
+        env:
+          APK_KEYSTORE_PASSWORD: ${{ secrets.APK_KEYSTORE_PASSWORD }}
+          APK_KEY_ALIAS:         ${{ secrets.APK_KEY_ALIAS }}
+          APK_KEY_PASSWORD:      ${{ secrets.APK_KEY_PASSWORD }}
+          REPO_KEY_ALIAS:        ${{ secrets.REPO_KEY_ALIAS }}
+
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid publish --verbose --error-on-failed "$APPID"
+
+      - name: Collect artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p fdroid-out
+          rsync -a --ignore-missing-args "$TMP_META_DIR/repo" "$TMP_META_DIR/unsigned" "$TMP_META_DIR/tmp" fdroid-out/ || true
+          find "$TMP_META_DIR" -type f \( -name '*.apk' -o -name '*.aab' -o -name 'index.xml' -o -name 'index-v1.json' \) -print0 \
+            | xargs -0 -I{} cp --parents {} fdroid-out/ || true
+          if [ -d "updated-metadata" ]; then
+            rsync -a "updated-metadata/" fdroid-out/updated-metadata/
+          fi
+          ls -R fdroid-out || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fdroids
+          path: fdroid-out/**
+          if-no-files-found: error

--- a/.github/workflows/repro.yml
+++ b/.github/workflows/repro.yml
@@ -79,10 +79,172 @@ jobs:
           compression-level: 0
           retention-days: 7
 
+  fdroid-build:
+    runs-on: ubuntu-latest
+    env:
+      TZ: UTC
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+      APPID: org.osservatorionessuno.bugbane
+      FDROID_BUILD: "1"
+
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Stable env
+        run: |
+          echo "TZ=UTC" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> $GITHUB_ENV
+          echo "LC_ALL=C.UTF-8" >> $GITHUB_ENV
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git curl locales \
+            python3 python3-pip python3-launchpadlib \
+            openjdk-17-jdk-headless apksigner mercurial \
+            jq unzip diffutils rsync
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platforms;android-36 build-tools;36.0.0
+
+      - name: Install Gradle
+        env:
+          GRADLE_VERSION: "8.13"
+        run: |
+          curl -L -o gradle-${GRADLE_VERSION}-bin.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+          unzip -q gradle-${GRADLE_VERSION}-bin.zip -d "$HOME/gradle"
+          echo "$HOME/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
+          gradle --version
+
+      - name: Add fdroidserver to PATH/ENV
+        run: |
+          git clone --depth 1 https://gitlab.com/fdroid/fdroidserver.git fdroidserver
+          cd fdroidserver
+          pip install --upgrade pip setuptools wheel
+          pip install .
+          cd ..
+          chmod +x fdroidserver/fdroid
+          echo "$GITHUB_WORKSPACE/fdroidserver" >> "$GITHUB_PATH"
+          echo "PYTHONPATH=$GITHUB_WORKSPACE/fdroidserver:$GITHUB_WORKSPACE/fdroidserver/examples" >> "$GITHUB_ENV"
+
+      - name: Prepare full fdroiddata
+        env:
+          APPID: ${{ env.APPID }}
+        run: |
+          set -euo pipefail
+          TMP_META_DIR="$(mktemp -d)"
+          echo "TMP_META_DIR=$TMP_META_DIR" >> $GITHUB_ENV
+          git clone --depth 1 https://gitlab.com/fdroid/fdroiddata.git "$TMP_META_DIR"
+          test -f "metadata/${APPID}.yml" || { echo "::error::metadata/${APPID}.yml not found"; exit 1; }
+          cp "metadata/${APPID}.yml" "$TMP_META_DIR/metadata/${APPID}.yml"
+          cd "$TMP_META_DIR"
+          cat > config.yml <<'YAML'
+          repo_url: https://example.invalid/repo
+          make_current_version_link: false
+          gradle: gradle
+          cachedir: /tmp/.cache/fdroid
+          gradle_version_dir: /home/runner/.gradle/wrapper/dists
+          YAML
+          git -C "$TMP_META_DIR" add "metadata/${APPID}.yml" "config.yml"
+          git -C "$TMP_META_DIR" config user.email "ci@example.invalid"
+          git -C "$TMP_META_DIR" config user.name  "CI"
+          git -C "$TMP_META_DIR" commit -m "Use custom metadata for ${APPID}" >/dev/null
+
+      - name: Pin metadata commit in temp repo
+        run: |
+          set -euo pipefail
+          TMP_META_DIR="${TMP_META_DIR:?}"
+          APPFILE="$TMP_META_DIR/metadata/${APPID}.yml"
+          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+            PIN=$(git describe --tags --abbrev=0)
+          else
+            PIN=$(git rev-parse HEAD)
+          fi
+          sed -i -E "0,/^(\s*commit:\s*).*/s//\1$PIN/" "$APPFILE"
+          git -C "$TMP_META_DIR" add "$APPFILE"
+          git -C "$TMP_META_DIR" commit -m "Pin commit to $PIN" >/dev/null
+          echo "PIN=$PIN" >> $GITHUB_ENV
+
+      - name: F-Droid build (unsigned)
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid build --verbose --no-tarball "$APPID"
+
+      - name: Restore combined keystore (APK + repo)
+        env:
+          APK_KEYSTORE_B64: ${{ secrets.APK_KEYSTORE_B64 }}
+        run: |
+          set -euo pipefail
+          echo "$APK_KEYSTORE_B64" | base64 -d > ci-two-keys.jks
+          chmod 600 ci-two-keys.jks
+          echo "CI_KEYSTORE=$GITHUB_WORKSPACE/ci-two-keys.jks" >> $GITHUB_ENV
+
+      - name: Append signing config to config.yml
+        env:
+          APK_KEYSTORE_PASSWORD: ${{ secrets.APK_KEYSTORE_PASSWORD }}
+          APK_KEY_ALIAS:         ${{ secrets.APK_KEY_ALIAS }}
+          APK_KEY_PASSWORD:      ${{ secrets.APK_KEY_PASSWORD }}
+          REPO_KEY_ALIAS:        ${{ secrets.REPO_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          {
+            echo "keystore: \"$CI_KEYSTORE\""
+            echo "keystorepass: \"$APK_KEYSTORE_PASSWORD\""
+            echo "keyalias: \"$APK_KEY_ALIAS\""     # APK signing
+            echo "keypass: \"$APK_KEY_PASSWORD\""
+            echo "keyaliases:"
+            echo "  ${APPID}: \"$APK_KEY_ALIAS\""
+            echo "repo_keyalias: \"$REPO_KEY_ALIAS\""  # index signing
+          } >> config.yml
+          chmod 600 config.yml
+
+      - name: F-Droid publish (signs APK into repo/)
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          fdroid publish --verbose --error-on-failed "$APPID"
+
+      - name: Collect signed APK
+        id: pick
+        run: |
+          set -euo pipefail
+          cd "$TMP_META_DIR"
+          # F-Droid names like repo/<appid>_<versionCode>.apk
+          FD_APK=$(ls -t repo/${APPID}_*.apk | head -n1)
+          echo "FD_APK=$FD_APK"
+          echo "fd_apk_path=$TMP_META_DIR/$FD_APK" >> $GITHUB_OUTPUT
+
+      - name: Upload F-Droid APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-fdroid
+          path: ${{ steps.pick.outputs.fd_apk_path }}
+          compression-level: 0
+          retention-days: 7
+
   repro-check:
     name: Reproducibility
     runs-on: ubuntu-24.04
-    needs: build
+    needs: [build, fdroid-build]   # <— depend on both
     steps:
       - name: Download APK from ubuntu-22.04
         uses: actions/download-artifact@v4
@@ -96,45 +258,59 @@ jobs:
           name: app-release-ubuntu-24.04
           path: ./artifacts/ubuntu-24.04
 
+      - name: Download F-Droid APK
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release-fdroid
+          path: ./artifacts/fdroid
+
       - name: Install tools
         run: |
           set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y1 --no-install-recommends \
-            apksigner \
-            apksigcopier \
-            androguard \
-            apktool \
-            diffoscope \
-            libarchive-tools \
-            default-jre-headless
+          sudo apt-get install -y --no-install-recommends \
+            apksigner apksigcopier androguard apktool diffoscope \
+            libarchive-tools default-jre-headless
 
-      - name: apksigcopier compare
-        id: apkcmp
+      - name: apksigcopier compare (22.04 vs 24.04)
         run: |
           set -euo pipefail
           A=./artifacts/ubuntu-22.04/app-release.apk
           B=./artifacts/ubuntu-24.04/app-release.apk
-          # apksigcopier prints nothing & exits 0 when it sees no relevant differences
-          apksigcopier compare "$A" "$B" | tee apksigcopier-compare.txt
-          status=${PIPESTATUS[0]}
-          if [ "$status" -ne 0 ]; then
-            echo "❌ apksigcopier compare failed (exit $status)."
-            exit "$status"
-          fi
-          if [ -s apksigcopier-compare.txt ]; then
-            echo "❌ apksigcopier reports differences."
-            exit 1
-          fi
-          echo "✅ apksigcopier reports no differences."
+          apksigcopier compare "$A" "$B" | tee apksigcopier-compare-22-vs-24.txt
+          [ ! -s apksigcopier-compare-22-vs-24.txt ] || { echo "diff detected"; exit 1; }
 
-      - name: diffoscope report
+      - name: apksigcopier compare (22.04 vs F-Droid)
+        run: |
+          set -euo pipefail
+          A=./artifacts/ubuntu-22.04/app-release.apk
+          F=(./artifacts/fdroid/*.apk)
+          apksigcopier compare "$A" "$F" | tee apksigcopier-compare-22-vs-fdroid.txt
+          [ ! -s apksigcopier-compare-22-vs-fdroid.txt ] || { echo "diff detected"; exit 1; }
+
+      - name: apksigcopier compare (24.04 vs F-Droid)
+        run: |
+          set -euo pipefail
+          B=./artifacts/ubuntu-24.04/app-release.apk
+          F=(./artifacts/fdroid/*.apk)
+          apksigcopier compare "$B" "$F" | tee apksigcopier-compare-24-vs-fdroid.txt
+          [ ! -s apksigcopier-compare-24-vs-fdroid.txt ] || { echo "diff detected"; exit 1; }
+
+      - name: diffoscope (22.04 vs F-Droid)
         continue-on-error: true
         run: |
           set -euxo pipefail
           A=./artifacts/ubuntu-22.04/app-release.apk
+          F=(./artifacts/fdroid/*.apk)
+          diffoscope "$A" "$F" | tee diffoscope-22-vs-fdroid.txt || true
+
+      - name: diffoscope (24.04 vs F-Droid)
+        continue-on-error: true
+        run: |
+          set -euxo pipefail
           B=./artifacts/ubuntu-24.04/app-release.apk
-          diffoscope "$A" "$B" | tee diffoscope.txt || true
+          F=(./artifacts/fdroid/*.apk)
+          diffoscope "$B" "$F" | tee diffoscope-24-vs-fdroid.txt || true
 
       - name: Upload reports
         if: always()
@@ -142,6 +318,6 @@ jobs:
         with:
           name: reproducibility-reports
           path: |
-            apksigcopier-compare.txt
-            diffoscope.txt
+            apksigcopier-compare-*.txt
+            diffoscope-*.txt
           retention-days: 7

--- a/metadata/org.osservatorionessuno.bugbane.yml
+++ b/metadata/org.osservatorionessuno.bugbane.yml
@@ -1,0 +1,36 @@
+Categories:
+  - Security
+  - System
+License: GPL-3.0-or-later
+AuthorName: Osservatorio Nessuno
+WebSite: https://osservatorionessuno.org
+SourceCode: https://github.com/osservatorionessuno/bugbane
+IssueTracker: https://github.com/osservatorionessuno/bugbane/issues
+Changelog: https://github.com/osservatorionessuno/bugbane/releases
+
+AutoName: Bugbane
+Summary: On-device Android forensics toolkit
+Description: |-
+  Bugbane is an open-source Android app that helps potential spyware and
+  stalkerware victims self-triage their devices and export evidence for
+  analysis when needed. It performs an on-device guided scan and uses ADB
+  Wireless Debugging to execute commands directly on the device.
+
+RepoType: git
+Repo: https://github.com/osservatorionessuno/bugbane.git
+
+Builds:
+  - versionName: 0.1.0
+    versionCode: 1
+    commit: HEAD
+    subdir: .
+    prebuild: |
+      gradle --version
+      gradle wrapper --gradle-version 8.13
+      chmod +x gradlew
+    gradle:
+      - yes
+    output: app/build/outputs/apk/release/app-release-unsigned.apk
+
+AutoUpdateMode: None
+UpdateCheckMode: None


### PR DESCRIPTION
Adds FDroid basic metadata, that are dynamically updated in CI at every commit. Upstream FDroid files should contain a precise release, but in this way we can build at every commit and ensure there is no issues. The reproducibility CI is also extended to build on both Github's Ubuntu images and via `fdroid publish`, then cross checking all three. Ideally, we'd also extend `fdroid publish` to check itself, either via local files or by using a local http server and the `Binaries` configuration.