### PR TITLE
Don't reset slideshow state when Settings -> Developer options is clicked

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
@@ -79,7 +79,6 @@ fun SettingsScreen() {
                 // Reset Slideshow Button
                 Button(
                     onClick = {
-                        SlideshowManager.resetHomepageState(context, true) // DEBUG: remove in production
                         ConfigurationManager.openDeveloperOptions(context)
                     },
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Remove a line that force-resets the slideshow state if the user navigates to settings -> developer options that looks like it was meant for testing only.

This line can cause a glitch where if you click it but don't make any permissions changes, the app enters an unrecoverable flickering state (tries to show homepage -> tries to advance past all the pages) which can only be fixed by clearing the app's local storage in the OS.

Sidenote: this is a small fix, but I'm still working on a draft of a refactored state-based workflow for the slideshow, which will hopefully mean maintaining a lot less state in separate places: see very rough WIP at https://github.com/osservatorionessuno/bugbane/compare/main...rocodes:bugbane:states 

