### PR TITLE
Remove native libs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,10 @@ android {
     }
 }
 
+configurations.all {
+    exclude(group = "androidx.graphics", module = "graphics-path")
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -73,8 +77,8 @@ dependencies {
     // libadb-android and its dependency
     implementation(libs.libadb.android)
     implementation(libs.sun.security.android)
-    // Required for ADB encryption
-    implementation(libs.conscrypt.android)
+    // Required to use native conscrypt
+    implementation(libs.hiddenapibypass)
 
     // Required for age encrypted export/share
     implementation(libs.kage)

--- a/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
@@ -17,10 +17,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import kotlinx.coroutines.launch
-import io.github.muntashirakon.adb.PRNGFixes
-import androidx.lifecycle.lifecycleScope
 import androidx.work.*
-import kotlinx.coroutines.Dispatchers
 import org.osservatorionessuno.libmvt.common.IndicatorsUpdates
 import org.osservatorionessuno.bugbane.workers.IndicatorsUpdateWorker
 import java.util.concurrent.TimeUnit
@@ -34,6 +31,7 @@ import org.osservatorionessuno.bugbane.utils.SlideshowManager
 import org.osservatorionessuno.bugbane.utils.AdbViewModel
 import org.osservatorionessuno.bugbane.utils.AdbPairingService
 import org.osservatorionessuno.bugbane.utils.ConfigurationManager
+import org.lsposed.hiddenapibypass.HiddenApiBypass
 
 class MainActivity : ComponentActivity() {
     private val viewModel: AdbViewModel by viewModels()
@@ -41,7 +39,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        PRNGFixes.apply()
+        HiddenApiBypass.addHiddenApiExemptions("L")
 
         // Observers
         viewModel.watchConnectAdb().observe(this) { isConnected ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,30 +1,31 @@
 [versions]
 agp                   = "8.11.1"
-kotlin                = "2.2.10"
+kotlin                = "2.2.20"
 coreKtx               = "1.17.0"
 junitVersion          = "1.3.0"
 espressoCore          = "3.7.0"
-lifecycleRuntimeKtx   = "2.9.3"
-activityCompose       = "1.10.1"
-composeBom            = "2025.08.01"
-navigationCompose     = "2.9.3"
+lifecycleRuntimeKtx   = "2.9.4"
+activityCompose       = "1.11.0"
+composeBom            = "2025.09.00"
+navigationCompose     = "2.9.4"
 junitJupiter          = "5.13.4"
-protobuf              = "4.32.0"
+protobuf              = "4.32.1"
 protobufPlugin        = "0.9.5"
 conscrypt             = "2.5.3"
 ahocorasick           = "0.6.3"
-libadb                = "3.0.0"
+libadb                = "3.1.0"
 sunSecurityAndroid    = "1.1"
-work                  = "2.10.3"
+work                  = "2.10.4"
 snakeyaml             = "2.5"
 kage                  = "0.3.0"
 json                  = "20250517"
+hiddenapibypass       = "6.1"
 
 [plugins]
 android-application   = { id = "com.android.application",            version.ref = "agp" }
 kotlin-android        = { id = "org.jetbrains.kotlin.android",       version.ref = "kotlin" }
 kotlin-compose        = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-junit5                = { id = "de.mannodermaus.android-junit5",     version = "1.13.1.0" }
+junit5                = { id = "de.mannodermaus.android-junit5",     version = "1.13.4.0" }
 protobuf              = { id = "com.google.protobuf",                version.ref = "protobufPlugin" }
 
 [libraries]
@@ -46,7 +47,6 @@ androidx-foundation               = { group = "androidx.compose.foundation", nam
 compose-material-icons-extended   = { group = "androidx.compose.material",   name = "material-icons-extended" }
 libadb-android                    = { group = "com.github.MuntashirAkon",    name = "libadb-android",         version.ref = "libadb" }
 sun-security-android              = { group = "com.github.MuntashirAkon",    name = "sun-security-android",   version.ref = "sunSecurityAndroid" }
-conscrypt-android                 = { group = "org.conscrypt",                name = "conscrypt-android",      version.ref = "conscrypt" }
 ahocorasick                       = { group = "org.ahocorasick",              name = "ahocorasick",            version.ref = "ahocorasick" }
 protobuf-javalite                 = { group = "com.google.protobuf",          name = "protobuf-javalite",      version.ref = "protobuf" }
 protoc                            = { group = "com.google.protobuf",          name = "protoc",                 version.ref = "protobuf" }
@@ -56,3 +56,4 @@ androidx-work-runtime-ktx         = { group = "androidx.work",              name
 snakeyaml                         = { group = "org.yaml",                   name = "snakeyaml",             version.ref = "snakeyaml" }
 kage                              = { group = "com.github.android-password-store", name = "kage", version.ref = "kage" }
 org-json                          = { group = "org.json",                     name = "json",                   version.ref = "json" }
+hiddenapibypass                   = { group = "org.lsposed.hiddenapibypass", name  = "hiddenapibypass", version.ref = "hiddenapibypass" }


### PR DESCRIPTION
This PR aims to remove all the native dependencies in Bugbane, if possible. This shrinks the APK sizes, as we do not need architecture specific code, and improves future reproducibility.

The biggest library was Conscrypt: I reverted back to the libadb-android instructions on using reflection (HiddenAPIBypass). At first I thught that required a native lib anyway, to bridge the NDK methods to the SDK, but when analyzing the APK, it doesn't look like that is the case.

Second, I'm excluding from the deps graph a native component of the graphics toolkit. I don't think we use it, but I should do extensive testing to check that it doesn't break anything.

Lastly, there's the spake2 implementation. In theory libadb-android uses spake2-java, but the library has also a native android implementation that is used by default. I tried to swap it, but it did not work and will investigate more, see: https://github.com/MuntashirAkon/libadb-android/issues/22


Also with this PR the release APK shrinks to half its size:
<img width="903" height="555" alt="image" src="https://github.com/user-attachments/assets/d76fd868-76dc-4309-b748-b7a72671926a" />
