### PR TITLE
Fix Acquisition-progress and Analysis-progress UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ gradlew.bat
 local.properties
 *.class
 .DS_Store
+*.code-workspace

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,10 @@
             android:name=".ScanDetailActivity"
             android:exported="false"
             android:theme="@style/Theme.Theme" />
+        <activity
+            android:name=".AboutActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Theme" />
         <service
             android:name=".utils.AdbPairingService"
             android:exported="false"

--- a/app/src/main/java/org/osservatorionessuno/bugbane/AboutActivity.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/AboutActivity.kt
@@ -1,0 +1,150 @@
+package org.osservatorionessuno.bugbane
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.osservatorionessuno.bugbane.ui.theme.Theme
+
+class AboutActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        enableEdgeToEdge()
+        setContent {
+            Theme {
+                AboutContent()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutContent() {
+    val context = LocalContext.current
+
+    val contactUrl = stringResource(R.string.about_contact_url)
+    val donateUrl = stringResource(R.string.about_donate_url)
+    
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.about_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { (context as? ComponentActivity)?.finish() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.about_organization_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.about_organization_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight * 1.2
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_VIEW).apply {
+                                data = Uri.parse(contactUrl)
+                            }
+                            context.startActivity(intent)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.secondary,
+                            contentColor = MaterialTheme.colorScheme.onSecondary
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Email,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.about_contact_button),
+                            style = MaterialTheme.typography.bodyLarge.copy(
+                                fontWeight = FontWeight.Medium
+                            )
+                        )
+                    }
+                    Button(
+                        onClick = {
+                            val intent = Intent(Intent.ACTION_VIEW).apply {
+                                data = Uri.parse(donateUrl)
+                            }
+                            context.startActivity(intent)
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Favorite,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.about_donate_button),
+                            style = MaterialTheme.typography.bodyLarge.copy(
+                                fontWeight = FontWeight.Medium
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/components/LayeredProgressIndicator.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/components/LayeredProgressIndicator.kt
@@ -1,0 +1,51 @@
+package org.osservatorionessuno.bugbane.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LayeredProgressIndicator(
+    totalModules: Int = 0,
+    completedModules: Int = 0,
+    modifier: Modifier = Modifier,
+    size: Dp = 48.dp,
+    strokeWidth: Dp = 4.dp,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    progressColor: Color = MaterialTheme.colorScheme.primary,
+    continuousColor: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+) {
+    Box(
+        modifier = modifier.size(size),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(size),
+            strokeWidth = strokeWidth,
+            color = continuousColor.copy(alpha = 0.4f),
+            trackColor = backgroundColor.copy(alpha = 0.4f)
+        )
+        
+        if (totalModules > 0) {
+            CircularProgressIndicator(
+                progress = { (completedModules / totalModules.toFloat()).coerceIn(0f, 1f) },
+                modifier = Modifier.size(size),
+                strokeWidth = strokeWidth,
+                color = progressColor,
+                trackColor = Color.Transparent
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text("$completedModules / $totalModules")
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -48,8 +48,6 @@ fun ScanScreen() {
     val adbManager = viewModel.adbManager
     val adbState = adbManager.adbState.collectAsStateWithLifecycle()
     
-    var isCancelling by remember { mutableStateOf(false) }
-
     var showDisableDialog by remember { mutableStateOf(false) }
     var completedModules by remember { mutableStateOf(0) }
     var totalModules by remember { mutableStateOf(0) }
@@ -64,7 +62,7 @@ fun ScanScreen() {
             .fillMaxSize()
             .padding(8.dp)
     ) {
-        if (adbState.value == AdbState.ConnectedAcquiring) {
+        if (adbState.value == AdbState.ConnectedAcquiring || adbState.value == AdbState.Cancelling) {
             Column(modifier = Modifier.fillMaxSize()) {
                 if (isLandscape) {
                     Row(modifier = Modifier.weight(1f)) {
@@ -125,12 +123,11 @@ fun ScanScreen() {
                 }
                 Button(
                     onClick = { 
-                        if (!isCancelling) {
-                            isCancelling = true
+                        if (adbState.value != AdbState.Cancelling) {
                             adbManager.cancelQuickForensics()
                         }
                     },
-                    enabled = !isCancelling,
+                    enabled = adbState.value != AdbState.Cancelling,
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.error
@@ -143,7 +140,7 @@ fun ScanScreen() {
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = if (isCancelling) stringResource(R.string.scan_cancelling_button) else stringResource(R.string.scan_cancel_button),
+                        text = if (adbState.value == AdbState.Cancelling) stringResource(R.string.scan_cancelling_button) else stringResource(R.string.scan_cancel_button),
                         style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
                     )
                 }
@@ -278,7 +275,6 @@ fun ScanScreen() {
                                 progressLogs.clear()
                                 moduleLogIndex.clear()
                                 moduleBytes.clear()
-                                isCancelling = false
                                 completedModules = 0
                                 totalModules = 0
                                 adbManager.runQuickForensics(baseDir, object : org.osservatorionessuno.bugbane.qf.QuickForensics.ProgressListener {
@@ -325,7 +321,6 @@ fun ScanScreen() {
                                                     context.startActivity(intent)
                                                 }
                                                 showDisableDialog = true
-                                                isCancelling = false
                                             }
                                         }
                                     }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
@@ -3,13 +3,17 @@ package org.osservatorionessuno.bugbane.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import android.content.Intent
+import org.osservatorionessuno.bugbane.BuildConfig
 import org.osservatorionessuno.bugbane.R
 import org.osservatorionessuno.bugbane.utils.ConfigurationManager
 import kotlinx.coroutines.Dispatchers
@@ -49,6 +53,14 @@ fun SettingsScreen() {
             .fillMaxSize()
             .padding(16.dp)
     ) {
+        Text(
+            text = stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
         Card(
             modifier = Modifier.fillMaxWidth(),
             elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
@@ -57,6 +69,12 @@ fun SettingsScreen() {
                 Text(
                     text = stringResource(R.string.settings_indicators_title),
                     style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.settings_indicators_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(text = stringResource(R.string.settings_indicators_last_fetch, formatEpoch(lastFetch)))
@@ -104,6 +122,50 @@ fun SettingsScreen() {
                 
                 Text(
                     text = stringResource(R.string.settings_developer_options_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp)
+            ) {
+                Button(
+                    onClick = {
+                        val intent = Intent(context, org.osservatorionessuno.bugbane.AboutActivity::class.java)
+                        context.startActivity(intent)
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.settings_about),
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontWeight = FontWeight.Medium
+                        )
+                    )
+                }
+                
+                Spacer(modifier = Modifier.height(8.dp))
+                
+                Text(
+                    text = stringResource(R.string.settings_about_desc),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbManager.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbManager.kt
@@ -299,11 +299,14 @@ class AdbManager(applicationContext: Context) {
                 io.printStackTrace()
                 commandOutput.postValue("Error running QuickForensics: " + io.message)
                 _adbState.value = AdbState.Cancelled
+                // Set the flag otherwise we will be stuck
+                qfCancelled.set(true);
             }
             catch (e: java.lang.Exception) {
                 e.printStackTrace()
                 commandOutput.postValue("Error running QuickForensics: " + e.message)
                 _adbState.value = AdbState.ErrorAcquisition
+                qfCancelled.set(true);
             }
         })
     }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbState.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbState.kt
@@ -10,10 +10,11 @@ enum class AdbState(val index: Int) {
     Connecting(2),
     ConnectedIdle(3), // AppStates >= AppState.AdbConnected
     ConnectedAcquiring(4),
-    Cancelled(5),
-    ErrorConnect(6),
-    ErrorAcquisition(7),
-    Initial(8); // Initializing state
+    Cancelling(5),
+    Cancelled(6),
+    ErrorConnect(7),
+    ErrorAcquisition(8),
+    Initial(9); // Initializing state
 
     companion object {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,10 +62,14 @@
     <string name="settings_general">General Settings</string>
     <string name="settings_developer_options">Disable Developer Options</string>
     <string name="settings_developer_options_desc">It\'s recommended to disable Developer Options after each session and re-enable them only when needed.</string>
-    <string name="settings_indicators_title">Indicators</string>
+    <string name="settings_indicators_title">Indicators of Compromise (IoCs)</string>
     <string name="settings_indicators_last_fetch">Last fetch: %1$s</string>
     <string name="settings_indicators_last_update">Last update: %1$s</string>
     <string name="settings_indicators_count">Indicator files: %1$d</string>
+    <string name="settings_indicators_desc">The indicators of compromise (IoCs) are used to identify signs of infections or surveillance on Android devices. They are updated periodically to ensure the accuracy of the analysis.</string>
+    <string name="settings_about">About Us</string>
+    <string name="settings_about_desc">Bugbane is an open-source project made by Osservatorio Nessuno. Learn more about Osservatorio Nessuno</string>
+    <string name="settings_version">Bugbane version: %1$s</string>
 
     <!-- Indicator update notification -->
     <string name="notification_channel_indicators">Indicators</string>
@@ -127,4 +131,15 @@
     <string name="analysis_details_acquisition_uuid">Acquisition UUID: %1$s</string>
     <string name="analysis_details_acquisition_completed">Acquisition completed: %1$s</string>
     <string name="analysis_details_analysis_completed">Analysis completed: %1$s</string>
+
+    <!-- About screen strings -->
+    <string name="about_title">About Us</string>
+    <string name="about_organization_title">Osservatorio Nessuno</string>
+    <string name="about_organization_description">Osservatorio Nessuno OdV is a registered non-profit Italian organization, run entirely by volunteers. We are committed to defending the right to privacy, anonymity, freedom of information, expression, and communication, as well as digital rights more broadly.
+    \n\n
+    For years, many of our members have voluntarily offered support to activists affected by technological repression, providing self-defense tools, consultations, and assistance to individuals under prosecution.</string>
+    <string name="about_contact_button">Contact Us</string>
+    <string name="about_contact_url">https://osservatorionessuno.org/contacts/</string>
+    <string name="about_donate_button">Donate</string>
+    <string name="about_donate_url">https://osservatorionessuno.org/donate/</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="scan_disable_dialog_button">Disable</string>
     <string name="scan_disable_dialog_close_button">Close</string>
     <string name="scan_cancel_button">Stop Acquisition</string>
+    <string name="scan_cancelling_button">Cancelling...</string>
 
     <!-- Settings screen strings -->
     <string name="settings_description">Configure your preferences and app settings here.</string>
@@ -107,6 +108,8 @@
     <string name="acquisition_details_export">Export</string>
     <string name="acquisition_details_share">Share</string>
     <string name="acquisition_details_rescan">Run Analysis</string>
+    <string name="analysis_in_progress">Analysis in progress...</string>
+    <string name="export_in_progress">Export in progress...</string>
 
     <!-- Messages for export/share passphrases -->
     <string name="acquisition_export_passphrase">The exported archive contains potentially private information and has been encrypted. The password will be shown only once:\n\n%1$s</string>


### PR DESCRIPTION
This PR addresses some minor UI/UX issues:

During the Acquisition process:
- Display a continuous progress indicator layered below the "Completed modules" indicator, so that the user knows acquisition is ongoing even if modules seems stuck (eg bugreportz)
- Disable the "Stop scanning" button and show the "Cancelling..." text until the process is actually terminated so the user is informed that it is doing something.

During the IOC Analysis of an acquisition:
- Make the progress indicator stand out graphically (added a background and a dialog)
- Disable all the buttons so they cannot be pressed while the analysis is still running

There is a one-line conflict with #37 so this PR will need to be rebased after the other is merged
