### PR TITLE
Use FOREGROUND_SERVICE_TYPE_SHORT_SERVICE for adb pairing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Permission for foreground service -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- Permission to check network state -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Currently used only to fetch IOCs -->

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbManager.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AdbManager.kt
@@ -71,7 +71,9 @@ class AdbManager(applicationContext: Context) {
             }
         }
 
-        // Cancel the notification, if it's still showing
+        // Cancel the notification, if it's still showing.
+        // Note: keep this cleanup despite onTimeout() in AdbPairingService, because Android
+        // versions < 34 don't call onTimeout().
         val stopIntent = AdbPairingService.stopIntent(appContext)
         appContext?.stopService(stopIntent)
     }


### PR DESCRIPTION
Instead of `FOREGROUND_SERVICE_TYPE_SPECIAL_USE`, which requires an additional permission and special explanation in the manifest, use `FOREGROUND_SERVICE_TYPE_SHORT_SERVICE` for adb pairing. More info: https://developer.android.com/reference/android/content/pm/ServiceInfo#FOREGROUND_SERVICE_TYPE_SHORT_SERVICE

Tested briefly on an EOL (pre-API 34) Android device, and pairing is still successful.  I have not tested the pairing and full acquisition workflow, so a diligent test plan would include that, but it should not be affected--the only foregrounded service is the pairing service.

Testing:
- [ ] visual review
- [ ] Successful pairing and acquisition
- [ ] Graceful timeout behaviour: on an android api >= 34 device, start the pairing service, then let the device sit idle for 3+ min. The pairing notification should be killed but no crashes should be present 
- [x] Pairing: compatibility with android API < 34
