### PR TITLE
Updates pipeline via OHTTP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,11 +79,15 @@ dependencies {
     implementation(libs.androidx.foundation)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.androidx.work.runtime.ktx)
-    implementation(libs.snakeyaml)
     implementation(libs.google.accompanist.permissions)
 
     // external libMVT
     implementation(libs.libmvt)
+
+    // OHTTP update transport (Oblivious HTTP, RFC 9458 + 9292 + 9180)
+    implementation(libs.libohttp)
+    implementation(libs.libbhttp)
+    implementation(libs.libohttp.hpke.bc)
 
     // libadb-android and its dependency
     implementation(libs.libadb.android)
@@ -94,8 +98,8 @@ dependencies {
     // Required for age encrypted export/share
     implementation(libs.kage)
 
-    // Quick string matching for mvt
-    implementation(libs.ahocorasick)
+    // Applying the update feed's unified-diff deltas
+    implementation(libs.java.diff.utils)
 
     // Tombstone protobuf (lite)
     implementation(libs.protobuf.javalite)

--- a/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import io.github.muntashirakon.adb.PRNGFixes
 import androidx.work.*
-import org.osservatorionessuno.libmvt.common.IndicatorsUpdates
+import org.osservatorionessuno.bugbane.update.IndicatorStore
 import org.osservatorionessuno.bugbane.workers.IndicatorsUpdateWorker
 import java.util.concurrent.TimeUnit
 import org.osservatorionessuno.bugbane.components.AppTopBar
@@ -78,8 +78,7 @@ class MainActivity : ComponentActivity() {
             .build()
 
         // Kick an immediate, one-time run if nothing has been downloaded yet
-        val updates = IndicatorsUpdates(filesDir.toPath(), null)
-        if (updates.latestUpdate == 0L) {
+        if (IndicatorStore(this).readState().version == 0) {
             val now = OneTimeWorkRequestBuilder<IndicatorsUpdateWorker>()
                 .setConstraints(constraints)
                 .addTag("IndicatorsUpdate") // common tag for querying later if you want

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/SettingsScreen.kt
@@ -18,7 +18,7 @@ import org.osservatorionessuno.bugbane.R
 import org.osservatorionessuno.bugbane.utils.ConfigurationManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.osservatorionessuno.libmvt.common.IndicatorsUpdates
+import org.osservatorionessuno.bugbane.update.IndicatorStore
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -27,7 +27,8 @@ import java.time.format.DateTimeFormatter
 fun SettingsScreen() {
     val context = LocalContext.current
 
-    val updates = remember { IndicatorsUpdates(context.filesDir.toPath(), null) }
+    val store = remember { IndicatorStore(context) }
+    var indicatorVersion by remember { mutableStateOf<Int?>(null) }
     var lastUpdate by remember { mutableStateOf<Long?>(null) }
     var lastFetch by remember { mutableStateOf<Long?>(null) }
     var indicatorCount by remember { mutableStateOf<Long?>(null) }
@@ -40,11 +41,17 @@ fun SettingsScreen() {
     fun formatEpoch(epoch: Long?): String =
         if (epoch == null || epoch == 0L) "N/A" else formatter.format(Instant.ofEpochSecond(epoch))
 
+    // Until an update has actually been adopted (version > 0), every field reads N/A.
+    val everUpdated = (indicatorVersion ?: 0) > 0
+    fun orNa(value: String): String = if (everUpdated) value else "N/A"
+
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            lastUpdate = updates.latestUpdate
-            lastFetch = updates.latestCheck
-            indicatorCount = updates.countIndicators()
+            val s = store.readState()
+            indicatorVersion = s.version
+            lastUpdate = s.lastUpdateEpoch
+            lastFetch = s.lastCheckEpoch
+            indicatorCount = s.objectCount.toLong()
         }
     }
 
@@ -77,9 +84,10 @@ fun SettingsScreen() {
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-                Text(text = stringResource(R.string.settings_indicators_last_fetch, formatEpoch(lastFetch)))
-                Text(text = stringResource(R.string.settings_indicators_last_update, formatEpoch(lastUpdate)))
-                Text(text = stringResource(R.string.settings_indicators_count, (indicatorCount?.toInt() ?: 0)))
+                Text(text = stringResource(R.string.settings_indicators_version, orNa((indicatorVersion ?: 0).toString())))
+                Text(text = stringResource(R.string.settings_indicators_last_fetch, orNa(formatEpoch(lastFetch))))
+                Text(text = stringResource(R.string.settings_indicators_last_update, orNa(formatEpoch(lastUpdate))))
+                Text(text = stringResource(R.string.settings_indicators_count, orNa((indicatorCount?.toInt() ?: 0).toString())))
             }
         }
 

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/DeltaPatch.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/DeltaPatch.kt
@@ -1,0 +1,25 @@
+package org.osservatorionessuno.bugbane.update
+
+import com.github.difflib.UnifiedDiffUtils
+import com.github.difflib.patch.PatchFailedException
+
+/**
+ * Applies the update feed's deltas (zero-context unified diffs produced by the bugbane-updater
+ * builder) using java-diff-utils. The result is only adopted if its SHA-256 equals the signed full
+ * hash, so the caller treats any failure here as a reason to fall back to a full download.
+ *
+ */
+object DeltaPatch {
+
+    /** @throws PatchFailedException if the diff's removed lines don't match [full] (e.g. corruption). */
+    fun apply(full: ByteArray, delta: ByteArray): ByteArray {
+        val source = String(full, Charsets.UTF_8).split("\n")
+        val deltaLines = String(delta, Charsets.UTF_8).split("\n").toMutableList()
+        // Drop the trailing empty element from the delta's own trailing newline before parsing.
+        if (deltaLines.isNotEmpty() && deltaLines.last().isEmpty()) deltaLines.removeAt(deltaLines.size - 1)
+
+        val patch = UnifiedDiffUtils.parseUnifiedDiff(deltaLines)
+        val out = patch.applyTo(source)
+        return out.joinToString("\n").toByteArray(Charsets.UTF_8)
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorStore.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorStore.kt
@@ -1,0 +1,119 @@
+package org.osservatorionessuno.bugbane.update
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Bugbane-owned on-disk state for the indicator feed, replacing libmvt's `IndicatorsUpdates` for
+ * everything except loading.
+ *
+ * State is scoped to the feed schema: moving to a new schema bootstraps from version 0.
+ */
+class IndicatorStore(private val filesDir: File) {
+
+    constructor(context: Context) : this(context.filesDir)
+
+    private val stateFile = File(filesDir, STATE_FILE)
+
+    /** Directory of STIX bundle files for libmvt to load. */
+    val indicatorsDir: File = File(filesDir, INDICATORS_DIR).apply { mkdirs() }
+
+    private val bundleFile: File = File(indicatorsDir, BUNDLE_FILE)
+
+    data class State(
+        val schema: Int = 0,
+        val version: Int = 0,
+        val sha256: String = "",
+        val sunset: String? = null,
+        val buildDate: String? = null,
+        val objectCount: Int = 0,
+        val lastCheckEpoch: Long = 0,
+        val lastUpdateEpoch: Long = 0,
+    )
+
+    /** Reads current state from disk. */
+    fun readState(): State {
+        if (!stateFile.exists()) return State()
+        return try {
+            val o = JSONObject(stateFile.readText())
+            State(
+                schema = o.optInt("schema", 0),
+                version = o.optInt("version", 0),
+                sha256 = o.optString("sha256", ""),
+                sunset = o.optString("sunset").ifBlank { null },
+                buildDate = o.optString("buildDate").ifBlank { null },
+                objectCount = o.optInt("objectCount", 0),
+                lastCheckEpoch = o.optLong("lastCheckEpoch", 0),
+                lastUpdateEpoch = o.optLong("lastUpdateEpoch", 0),
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not read update state; treating as empty", e)
+            State()
+        }
+    }
+
+    fun writeState(state: State) {
+        val o = JSONObject()
+            .put("schema", state.schema)
+            .put("version", state.version)
+            .put("sha256", state.sha256)
+            .put("sunset", state.sunset)
+            .put("buildDate", state.buildDate)
+            .put("objectCount", state.objectCount)
+            .put("lastCheckEpoch", state.lastCheckEpoch)
+            .put("lastUpdateEpoch", state.lastUpdateEpoch)
+        atomicWrite(stateFile, o.toString().toByteArray(Charsets.UTF_8))
+    }
+
+    /** The locally adopted full bundle, or null if none has been written. */
+    fun readBundle(): ByteArray? = if (bundleFile.exists()) bundleFile.readBytes() else null
+
+    /** Atomically replace the indicators directory contents with a single full STIX bundle. */
+
+    fun writeBundle(bytes: ByteArray): Int {
+        indicatorsDir.listFiles()?.forEach { f ->
+            if (f != bundleFile && (f.name.endsWith(".json") || f.name.endsWith(".stix2"))) f.delete()
+        }
+        val tmp = File(indicatorsDir, bundleFile.name + ".tmp")
+        var newlines = 0
+        tmp.outputStream().use { out ->
+            var i = 0
+            while (i < bytes.size) {
+                val end = minOf(i + COPY_CHUNK, bytes.size)
+                for (j in i until end) if (bytes[j] == NL) newlines++
+                out.write(bytes, i, end - i)
+                i = end
+            }
+        }
+        rename(tmp, bundleFile)
+        return objectCount(newlines)
+    }
+
+    fun countObjects(bytes: ByteArray): Int = objectCount(bytes.count { it == NL })
+
+    private fun objectCount(newlines: Int): Int = (newlines - 2).coerceAtLeast(0)
+
+    private fun atomicWrite(target: File, bytes: ByteArray) {
+        val tmp = File(target.parentFile, target.name + ".tmp")
+        tmp.writeBytes(bytes)
+        rename(tmp, target)
+    }
+
+    private fun rename(tmp: File, target: File) {
+        if (!tmp.renameTo(target)) {
+            target.delete()
+            if (!tmp.renameTo(target)) throw java.io.IOException("Could not replace ${target.name}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "IndicatorStore"
+        private const val STATE_FILE = "indicator_update_state.json"
+        private const val INDICATORS_DIR = "bugbane-indicators"
+        private const val BUNDLE_FILE = "indicators.json"
+        private const val COPY_CHUNK = 64 * 1024
+        private val NL = '\n'.code.toByte()
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorUpdater.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorUpdater.kt
@@ -1,0 +1,165 @@
+package org.osservatorionessuno.bugbane.update
+
+import android.content.Context
+import android.util.Log
+
+/**
+ * Drives the indicator update feed over OHTTP (see bugbane-updater's protocol).
+ *
+ * Flow per run:
+ *   1. GET `v<schema>/update.json`, read the `signed` metadata.
+ *   2. If `signed.schema` is unknown, keep last-good indicators and surface staleness.
+ *   3. If version+hash match local state, do nothing.
+ *   4. If 1..[DELTA_WINDOW] versions ahead, fetch and apply the delta; otherwise download the full.
+ *   5. Adopt the result only if its SHA-256 equals `signed.sha256`; on any delta failure, fall back
+ *      to the full. The local hash is stored and compared.
+ *
+ */
+class IndicatorUpdater(
+    private val store: IndicatorStore,
+    private val transport: UpdateTransport,
+    private val now: () -> Long = { System.currentTimeMillis() / 1000 },
+) {
+    constructor(context: Context) : this(IndicatorStore(context), OhttpTransport())
+
+    sealed interface Outcome {
+        val sunset: SunsetStatus
+
+        data class UpToDate(override val sunset: SunsetStatus) : Outcome
+        data class UnknownSchema(val schema: Int, override val sunset: SunsetStatus) : Outcome
+        data class Failed(val reason: String, override val sunset: SunsetStatus = SunsetStatus.None) : Outcome
+        data class Updated(
+            val fromVersion: Int,
+            val toVersion: Int,
+            val viaDelta: Boolean,
+            val newObjects: Int,
+            override val sunset: SunsetStatus,
+        ) : Outcome
+    }
+
+    fun runUpdate(): Outcome {
+        val meta = try {
+            val resp = transport.get("$BASE/update.json")
+            if (resp.statusCode != 200) return Outcome.Failed("update.json -> inner status ${resp.statusCode}")
+            UpdateMetadata.parse(resp.body)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch update.json", e)
+            return Outcome.Failed("update.json fetch failed: ${e.message}")
+        }
+
+        val sunset = SunsetStatus.evaluate(meta.sunset).also { SunsetStatus.log(it) }
+        val local = store.readState()
+        val checkedAt = now()
+
+        if (meta.schema != SCHEMA) {
+            Log.w(TAG, "Unknown feed schema ${meta.schema} (this app supports $SCHEMA); keeping last-good indicators")
+            store.writeState(local.copy(lastCheckEpoch = checkedAt))
+            return Outcome.UnknownSchema(meta.schema, sunset)
+        }
+
+        val upToDate = meta.version == local.version && meta.sha256 == local.sha256
+        val behind = meta.version < local.version
+        if (upToDate || behind) {
+            if (behind) Log.w(TAG, "Feed version ${meta.version} is behind local ${local.version}; keeping local")
+            else Log.i(TAG, "Indicators up to date (schema $SCHEMA, version ${meta.version})")
+            store.writeState(local.copy(lastCheckEpoch = checkedAt))
+            return Outcome.UpToDate(sunset)
+        }
+
+        val gap = meta.version - local.version
+        val localFull = store.readBundle()
+        val canDelta = local.version > 0 && local.schema == SCHEMA && gap in 1..DELTA_WINDOW && localFull != null
+
+        var viaDelta = false
+        var verified: Verified? = null
+        if (canDelta) {
+            verified = tryDelta(localFull!!, local.version, meta)
+            viaDelta = verified != null
+        }
+        if (verified == null) {
+            verified = fetchFull(meta) ?: return Outcome.Failed("full download failed", sunset)
+        }
+
+        // Disk is touched only now, after the bytes verified against the hash we computed. State
+        // records that computed hash (over the exact bytes written), not the server-provided value,
+        // so `state.sha256 == hash(bundle on disk)` holds by construction.
+        val objectCount = store.writeBundle(verified.bytes)
+        store.writeState(
+            IndicatorStore.State(
+                schema = meta.schema,
+                version = meta.version,
+                sha256 = verified.sha256,
+                sunset = meta.sunset,
+                buildDate = meta.buildDate,
+                objectCount = objectCount,
+                lastCheckEpoch = checkedAt,
+                lastUpdateEpoch = checkedAt,
+            ),
+        )
+        Log.i(TAG, "Adopted version ${meta.version} (${if (viaDelta) "delta" else "full"}), $objectCount objects")
+        return Outcome.Updated(
+            fromVersion = local.version,
+            toVersion = meta.version,
+            viaDelta = viaDelta,
+            newObjects = (objectCount - local.objectCount).coerceAtLeast(0),
+            sunset = sunset,
+        )
+    }
+
+    /** Fetch and apply `delta-<local>-<target>.diff`; returns the reconstructed full iff the hash we
+     *  compute over it matches the feed's advertised hash. */
+    private fun tryDelta(localFull: ByteArray, localVersion: Int, meta: UpdateMetadata): Verified? {
+        return try {
+            val resp = transport.get("$BASE/deltas/delta-$localVersion-${meta.version}.diff")
+            if (resp.statusCode != 200) {
+                Log.i(TAG, "Delta delta-$localVersion-${meta.version} not available (status ${resp.statusCode}); using full")
+                return null
+            }
+            val candidate = DeltaPatch.apply(localFull, resp.body)
+            val hash = OhttpTransport.sha256Hex(candidate)
+            if (hash == meta.sha256) {
+                Verified(candidate, hash)
+            } else {
+                Log.w(TAG, "Delta result hash mismatch; falling back to full")
+                null
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Delta apply failed; falling back to full", e)
+            null
+        }
+    }
+
+    /** Download the content-addressed full bundle and return it iff the hash we compute matches. */
+    private fun fetchFull(meta: UpdateMetadata): Verified? {
+        return try {
+            val resp = transport.get("$BASE/${meta.sha256}.json")
+            if (resp.statusCode != 200) {
+                Log.e(TAG, "Full ${meta.sha256}.json -> inner status ${resp.statusCode}")
+                return null
+            }
+            val hash = OhttpTransport.sha256Hex(resp.body)
+            if (hash != meta.sha256) {
+                Log.e(TAG, "Full bundle hash mismatch (expected ${meta.sha256}, got $hash)")
+                return null
+            }
+            Verified(resp.body, hash)
+        } catch (e: Exception) {
+            Log.e(TAG, "Full download failed", e)
+            null
+        }
+    }
+
+    /** A bundle whose SHA-256 we computed ourselves and confirmed equals the feed's advertised hash. */
+    private class Verified(val bytes: ByteArray, val sha256: String)
+
+    companion object {
+        private const val TAG = "IndicatorUpdater"
+
+        /** Feed schema this app understands; also the path prefix on the origin. */
+        const val SCHEMA = 1
+        private const val BASE = "/v$SCHEMA"
+
+        /** Builder publishes deltas to the previous 5 versions. */
+        const val DELTA_WINDOW = 5
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
@@ -1,0 +1,128 @@
+package org.osservatorionessuno.bugbane.update
+
+import android.util.Log
+import org.osservatorionessuno.libbhttp.BhttpRequest
+import org.osservatorionessuno.libbhttp.BhttpResponse
+import org.osservatorionessuno.libbhttp.decodeResponse
+import org.osservatorionessuno.libbhttp.encodeRequest
+import org.osservatorionessuno.libohttp.MEDIA_TYPE_REQUEST
+import org.osservatorionessuno.libohttp.MEDIA_TYPE_RESPONSE
+import org.osservatorionessuno.libohttp.OhttpClient
+import org.osservatorionessuno.libohttp.bouncycastle.BouncyCastleHpkeBackend
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Oblivious HTTP (RFC 9458) transport for the indicator update feed.
+ *
+ * Every update request is encoded as BHTTP, encapsulated against the gateway's key config, and
+ * POSTed through an Oblivious relay so the gateway never sees the client address.
+ *
+ * The key config is shipped with the app ([EMBEDDED_KEY_CONFIG]).
+ */
+class OhttpTransport : UpdateTransport {
+    private val client: OhttpClient = OhttpClient.fromKeyConfigList(EMBEDDED_KEY_CONFIG, BouncyCastleHpkeBackend())
+
+    /**
+     * Issue an oblivious GET for [path] (an absolute path on the update origin, e.g. `/v1/update.json`)
+     * and return the decoded inner BHTTP response.
+     */
+    override fun get(path: String): BhttpResponse {
+        val bhttp = encodeRequest(
+            BhttpRequest(
+                method = "GET",
+                scheme = TARGET_SCHEME,
+                authority = TARGET_AUTHORITY,
+                path = path,
+                headers = listOf("accept" to "*/*"),
+            ),
+        )
+        val encapsulated = client.encapsulateRequest(bhttp)
+        val ohttpResponse = relayPost(encapsulated.bytes)
+        val responseBytes = encapsulated.decapsulateResponse(ohttpResponse)
+        val response = decodeResponse(responseBytes)
+        Log.i(TAG, "GET $path -> inner status ${response.statusCode}, ${response.body.size} bytes")
+        return response
+    }
+
+    /** POST the encapsulated request to the relay (the only host the client talks to) and return the
+     * raw `message/ohttp-res` bytes. */
+    private fun relayPost(body: ByteArray): ByteArray {
+        val conn = (URL(RELAY_URL).openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = TIMEOUT_MS
+            readTimeout = TIMEOUT_MS
+            setRequestProperty("Accept", MEDIA_TYPE_RESPONSE)
+            setRequestProperty("Content-Type", MEDIA_TYPE_REQUEST)
+            doOutput = true
+            setFixedLengthStreamingMode(body.size)
+        }
+        try {
+            conn.outputStream.use { it.write(body) }
+            val code = conn.responseCode
+            if (code !in 200..299) {
+                val err = conn.errorStream?.use { it.readBytes() } ?: ByteArray(0)
+                throw IOException("POST $RELAY_URL -> HTTP $code (${err.size} bytes of error body)")
+            }
+            return conn.inputStream.use { readBounded(it) }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    /**
+     * Read the relay response with a hard ceiling. The relay is a separate, not-fully-trusted party,
+     * so an unbounded read would let a rogue relay OOM the app; [MAX_RESPONSE_BYTES] bounds it while
+     * leaving generous headroom over the real bundle size.
+     */
+    private fun readBounded(input: InputStream): ByteArray {
+        val buffer = ByteArrayOutputStream()
+        val chunk = ByteArray(64 * 1024)
+        var total = 0L
+        while (true) {
+            val n = input.read(chunk)
+            if (n < 0) break
+            total += n
+            if (total > MAX_RESPONSE_BYTES) throw IOException("relay response exceeds $MAX_RESPONSE_BYTES bytes")
+            buffer.write(chunk, 0, n)
+        }
+        return buffer.toByteArray()
+    }
+
+    companion object {
+        const val TAG = "OhttpTransport"
+
+        /**
+         * Gateway key config (RFC 9458 §3, the `application/ohttp-keys` length-prefixed list format),
+         * shipped with the app. On key rotation, regenerate from `https://update.bugbane.org/ohttp-keys`
+         * and ship the new bytes in an app update.
+         * sha256 = 58a88a2136d3871cc9ab78786bc04b3aa91eb27076e964f5c729070e5a8252cc (pinned 2026-06).
+         */
+        private val EMBEDDED_KEY_CONFIG: ByteArray =
+            Base64.getDecoder().decode("AC0BACBD/fKo5k/IUJ08ZOvqwhq7bZYEO6noR2al+vbhKIsyEwAIAAEAAQABAAM=")
+
+        /**
+         * Oblivious relay resource that forwards encapsulated requests to our gateway. This relay
+         * resource is configured to forward to the `/gateway` endpoint on [TARGET_AUTHORITY].
+         */
+        const val RELAY_URL = "https://relay.oblivious.network/moving-mist-26"
+
+        /** Inner (gateway-side) request origin — where update.json / fulls / deltas live. */
+        const val TARGET_SCHEME = "https"
+        const val TARGET_AUTHORITY = "update.bugbane.org"
+
+        private const val TIMEOUT_MS = 15_000
+
+        /** Hard ceiling on a single relay response (128MB). */
+        private const val MAX_RESPONSE_BYTES = 128L * 1024 * 1024
+
+        fun sha256Hex(bytes: ByteArray): String =
+            MessageDigest.getInstance("SHA-256").digest(bytes)
+                .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/SunsetStatus.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/SunsetStatus.kt
@@ -1,0 +1,43 @@
+package org.osservatorionessuno.bugbane.update
+
+import android.util.Log
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+/**
+ * Harness for the feed's `sunset` field. Evaluation only for now
+ */
+sealed interface SunsetStatus {
+    /** No sunset advertised by the feed. */
+    object None : SunsetStatus
+
+    /** A sunset is set but still in the future: prompt the user to update before [date]. */
+    data class Upcoming(val date: LocalDate) : SunsetStatus
+
+    /** The sunset has passed: keep last-good indicators and tell the user to update the app. */
+    data class Reached(val date: LocalDate) : SunsetStatus
+
+    companion object {
+        const val TAG = "IndicatorSunset"
+
+        fun evaluate(sunset: String?, today: LocalDate = LocalDate.now()): SunsetStatus {
+            if (sunset.isNullOrBlank()) return None
+            val date = try {
+                LocalDate.parse(sunset)
+            } catch (e: DateTimeParseException) {
+                Log.w(TAG, "Ignoring unparseable sunset value '$sunset'", e)
+                return None
+            }
+            return if (today.isBefore(date)) Upcoming(date) else Reached(date)
+        }
+
+        /** Log the status. Placeholder for the future user-facing prompt (no popup yet). */
+        fun log(status: SunsetStatus) {
+            when (status) {
+                is None -> {}
+                is Upcoming -> Log.w(TAG, "App update required before ${status.date} to keep receiving indicator updates")
+                is Reached -> Log.w(TAG, "Indicator update line sunset on ${status.date}; update the app to continue receiving updates")
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateMetadata.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateMetadata.kt
@@ -1,0 +1,36 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.json.JSONObject
+
+/**
+ * The `signed` metadata of an `update.json` document.
+ *
+ * `update.json` is either `{"proofs": {...}, "signed": {...}}` (sealed) or the bare `signed` object
+ * (unsigned build). We read the `signed` subtree if present, else the document itself. Signature
+ * proofs are intentionally ignored for now. Unknown fields are preserved-by-ignoring per the feed's
+ * client contract.
+ */
+data class UpdateMetadata(
+    val schema: Int,
+    val version: Int,
+    val sha256: String,
+    val buildDate: String?,
+    /** Optional ISO date (e.g. "2027-01-01") after which the app must be updated to keep receiving updates. */
+    val sunset: String?,
+) {
+    companion object {
+
+        fun parse(bytes: ByteArray): UpdateMetadata {
+            val doc = JSONObject(String(bytes, Charsets.UTF_8))
+            val signed = doc.optJSONObject("signed") ?: doc
+            val sha256 = signed.getString("sha256").lowercase()
+            return UpdateMetadata(
+                schema = signed.getInt("schema"),
+                version = signed.getInt("version"),
+                sha256 = sha256,
+                buildDate = signed.optString("build_date").ifBlank { null },
+                sunset = signed.optString("sunset").ifBlank { null },
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateTransport.kt
@@ -1,0 +1,12 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.osservatorionessuno.libbhttp.BhttpResponse
+
+/**
+ * Minimal transport seam the updater fetches over. The production implementation is [OhttpTransport]
+ * (Oblivious HTTP); tests substitute an in-memory fake so the update logic can be exercised without
+ * a network or HPKE.
+ */
+interface UpdateTransport {
+    fun get(path: String): BhttpResponse
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/workers/IndicatorsUpdateWorker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/workers/IndicatorsUpdateWorker.kt
@@ -14,8 +14,8 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.osservatorionessuno.libmvt.common.IndicatorsUpdates
 import org.osservatorionessuno.bugbane.R
+import org.osservatorionessuno.bugbane.update.IndicatorUpdater
 import java.io.File
 import java.io.RandomAccessFile
 
@@ -38,17 +38,21 @@ class IndicatorsUpdateWorker(
                 return@withContext Result.success()
             }
             try {
-                val updates = IndicatorsUpdates(applicationContext.filesDir.toPath(), null)
-                val before = updates.countIndicators()
-                Log.i(TAG, "Starting indicator update with $before existing files")
-
-                updates.update()
-
-                val after = updates.countIndicators()
-                val diff = after - before
-                Log.i(TAG, "Indicator update finished, $after files total")
-                if (diff > 0) notify(applicationContext, diff)
-                Result.success()
+                Log.i(TAG, "Starting OHTTP indicator update")
+                val outcome = IndicatorUpdater(applicationContext).runUpdate()
+                when (outcome) {
+                    is IndicatorUpdater.Outcome.Updated -> {
+                        Log.i(TAG, "Updated v${outcome.fromVersion} -> v${outcome.toVersion} " +
+                            "(${if (outcome.viaDelta) "delta" else "full"}), ${outcome.newObjects} new")
+                        if (outcome.newObjects > 0) notify(applicationContext, outcome.newObjects.toLong())
+                        Result.success()
+                    }
+                    is IndicatorUpdater.Outcome.Failed -> {
+                        Log.e(TAG, "Indicator update failed: ${outcome.reason}")
+                        Result.retry()
+                    }
+                    else -> Result.success()
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Indicator update failed", e)
                 Result.retry()

--- a/app/src/main/java/org/osservatorionessuno/qf/AcquisitionScanner.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/AcquisitionScanner.kt
@@ -7,7 +7,7 @@ import org.osservatorionessuno.bugbane.utils.Utils
 import org.osservatorionessuno.bugbane.utils.initLibmvtLogging
 import org.osservatorionessuno.libmvt.android.ForensicRunner
 import org.osservatorionessuno.libmvt.common.Indicators
-import org.osservatorionessuno.libmvt.common.IndicatorsUpdates
+import org.osservatorionessuno.bugbane.update.IndicatorStore
 import org.osservatorionessuno.bugbane.utils.AndroidStringResolver
 import java.io.File
 import java.time.Instant
@@ -17,7 +17,7 @@ object AcquisitionScanner {
     fun scan(context: Context, acquisitionDir: File): File {
         initLibmvtLogging()
 
-        val indicatorsDir = IndicatorsUpdates(context.filesDir.toPath(), null).getIndicatorsFolder().toFile()
+        val indicatorsDir = IndicatorStore(context).indicatorsDir
         return scanWithIndicators(context, acquisitionDir, indicatorsDir)
     }
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -47,9 +47,10 @@
     <string name="settings_developer_options">Disabilita opzioni sviluppatore</string>
     <string name="settings_developer_options_desc">Si raccomanda di disabilitare le opzioni sviluppatore dopo ogni sessione e ri-abilitarle solamente quando necessario.</string>
     <string name="settings_indicators_title">Indicatori</string>
+    <string name="settings_indicators_version">Versione: %1$s</string>
     <string name="settings_indicators_last_fetch">Ultimo download: %1$s</string>
     <string name="settings_indicators_last_update">Ultimo aggiornamento: %1$s</string>
-    <string name="settings_indicators_count">File indicatori: %1$d</string>
+    <string name="settings_indicators_count">File indicatori: %1$s</string>
     <string name="notification_channel_indicators">Indicatori</string>
     <string name="notification_indicators_updated">Scaricati %1$d nuovi indicatori</string>
     <string name="acquisitions_title">Acquisizioni</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,9 +70,10 @@
     <string name="settings_developer_options">Disable Developer Options</string>
     <string name="settings_developer_options_desc">It\'s recommended to disable Developer Options after each session and re-enable them only when needed.</string>
     <string name="settings_indicators_title">Indicators of Compromise (IoCs)</string>
+    <string name="settings_indicators_version">Version: %1$s</string>
     <string name="settings_indicators_last_fetch">Last fetch: %1$s</string>
     <string name="settings_indicators_last_update">Last update: %1$s</string>
-    <string name="settings_indicators_count">Indicator files: %1$d</string>
+    <string name="settings_indicators_count">Indicator files: %1$s</string>
     <string name="settings_indicators_desc">The indicators of compromise (IoCs) are used to identify signs of infections or surveillance on Android devices. They are updated periodically to ensure the accuracy of the analysis.</string>
     <string name="settings_about">About Us &amp; Credits</string>
     <string name="settings_about_desc">Bugbane is an open-source project developed by Osservatorio Nessuno OdV.</string>

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/DeltaPatchTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/DeltaPatchTest.kt
@@ -1,0 +1,36 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Cross-implementation parity check: the fixtures below were produced by the bugbane-updater
+ * builder (`bundle_bytes` + `delta_bytes`) for a change that modifies, deletes, and inserts objects
+ * across multiple hunks. [DeltaPatch.apply] must reconstruct the exact new bundle bytes and hash.
+ */
+class DeltaPatchTest {
+    private fun b64(s: String) = Base64.getDecoder().decode(s)
+
+    private val old = b64(
+        "eyJpZCI6ImJ1bmRsZS0tOGYxZDZjM2UtMmE0Yi01YzZkLThlOWYtMGExYjJjM2Q0ZTVmIiwib2JqZWN0cyI6Wwp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCnsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDAzIiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifQpdLCJ0eXBlIjoiYnVuZGxlIn0K",
+    )
+    private val new = b64(
+        "eyJpZCI6ImJ1bmRsZS0tOGYxZDZjM2UtMmE0Yi01YzZkLThlOWYtMGExYjJjM2Q0ZTVmIiwib2JqZWN0cyI6Wwp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2NoYW5nZWQuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCnsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA0IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDYiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0KXSwidHlwZSI6ImJ1bmRsZSJ9Cg==",
+    )
+    private val delta = b64(
+        "LS0tIG9sZAorKysgbmV3CkBAIC0zLDMgKzMsNCBAQAoteyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCi17ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMyIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKLXsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA1IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9Cit7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMiIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnY2hhbmdlZC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKK3siaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA0IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAoreyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDUiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCit7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNiIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifQo=",
+    )
+    private val newSha = "461ac917421bbe122b08be61e90a59572a5b7f4af55fcf51285daa3f55e463ea"
+
+    @Test
+    fun reproducesFullBundleBytesAndHash() {
+        val result = DeltaPatch.apply(old, delta)
+        assertEquals(String(new, Charsets.UTF_8), String(result, Charsets.UTF_8))
+        assertEquals(newSha, sha256Hex(result))
+    }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorStoreTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorStoreTest.kt
@@ -1,0 +1,57 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class IndicatorStoreTest {
+
+    @TempDir
+    lateinit var tmp: File
+
+    @Test
+    fun stateRoundTrips() {
+        val store = IndicatorStore(tmp)
+        assertEquals(IndicatorStore.State(), store.readState()) // defaults when absent
+
+        val state = IndicatorStore.State(
+            schema = 1, version = 7, sha256 = "abc", sunset = "2027-01-01",
+            buildDate = "2026-06-13T00:00:00Z", objectCount = 42,
+            lastCheckEpoch = 111, lastUpdateEpoch = 222,
+        )
+        store.writeState(state)
+        assertEquals(state, store.readState())
+    }
+
+    @Test
+    fun writeBundleClearsStaleIndicatorFilesAndCounts() {
+        val dir = IndicatorStore(tmp).indicatorsDir
+        // Pre-existing stale indicator files that a previous mechanism might have left behind.
+        File(dir, "old-a.json").writeText("{}")
+        File(dir, "old-b.stix2").writeText("{}")
+
+        val store = IndicatorStore(tmp)
+        // Builder framing: head line, one object per line, tail line, trailing newline.
+        val bundle = ("""{"id":"bundle--x","objects":[""" + "\n" +
+            """{"id":"indicator--1"},""" + "\n" +
+            """{"id":"indicator--2"}""" + "\n" +
+            """],"type":"bundle"}""" + "\n").toByteArray()
+        store.writeBundle(bundle)
+
+        val names = dir.listFiles()!!.map { it.name }.toSet()
+        assertFalse("old-a.json" in names)
+        assertFalse("old-b.stix2" in names)
+        assertTrue("indicators.json" in names)
+        assertEquals(2, store.countObjects(bundle))
+        assertEquals(0, store.countObjects("not json".toByteArray()))
+    }
+
+    @Test
+    fun readBundleNullWhenAbsent() {
+        assertNull(IndicatorStore(tmp).readBundle())
+    }
+}

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorUpdaterTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorUpdaterTest.kt
@@ -1,0 +1,277 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.osservatorionessuno.libbhttp.BhttpResponse
+import java.io.File
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Exercises every branch of [IndicatorUpdater] against an in-memory [UpdateTransport] and a real
+ * on-disk [IndicatorStore] (temp dir). Bundles/deltas are the same fixtures the bugbane-updater
+ * builder emits (see [DeltaPatchTest]); the "old" bundle is versions [obj1,obj2,obj3,obj5] and the
+ * "new" bundle is [obj1,obj2',obj4,obj5,obj6].
+ */
+class IndicatorUpdaterTest {
+
+    @TempDir
+    lateinit var tmp: File
+
+    // --- fixtures (base64, produced by the Python builder) -----------------------------------------
+    private val oldBundle = b64(
+        "eyJpZCI6ImJ1bmRsZS0tOGYxZDZjM2UtMmE0Yi01YzZkLThlOWYtMGExYjJjM2Q0ZTVmIiwib2JqZWN0cyI6Wwp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCnsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDAzIiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifQpdLCJ0eXBlIjoiYnVuZGxlIn0K",
+    )
+    private val newBundle = b64(
+        "eyJpZCI6ImJ1bmRsZS0tOGYxZDZjM2UtMmE0Yi01YzZkLThlOWYtMGExYjJjM2Q0ZTVmIiwib2JqZWN0cyI6Wwp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2NoYW5nZWQuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCnsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA0IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAp7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNSIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKeyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDYiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0KXSwidHlwZSI6ImJ1bmRsZSJ9Cg==",
+    )
+    private val delta = b64(
+        "LS0tIG9sZAorKysgbmV3CkBAIC0zLDMgKzMsNCBAQAoteyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDIiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCi17ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMyIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKLXsiaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA1IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9Cit7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwMiIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnY2hhbmdlZC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifSwKK3siaWQiOiJpbmRpY2F0b3ItLTAwMDAwMDA0IiwicGF0dGVybiI6Iltkb21haW4tbmFtZTp2YWx1ZSA9ICdldmlsLmNvbSddIiwidHlwZSI6ImluZGljYXRvciJ9LAoreyJpZCI6ImluZGljYXRvci0tMDAwMDAwMDUiLCJwYXR0ZXJuIjoiW2RvbWFpbi1uYW1lOnZhbHVlID0gJ2V2aWwuY29tJ10iLCJ0eXBlIjoiaW5kaWNhdG9yIn0sCit7ImlkIjoiaW5kaWNhdG9yLS0wMDAwMDAwNiIsInBhdHRlcm4iOiJbZG9tYWluLW5hbWU6dmFsdWUgPSAnZXZpbC5jb20nXSIsInR5cGUiOiJpbmRpY2F0b3IifQo=",
+    )
+    private val shaOld get() = sha(oldBundle)
+    private val shaNew get() = sha(newBundle)
+
+    // --- helpers -----------------------------------------------------------------------------------
+    private fun b64(s: String) = Base64.getDecoder().decode(s)
+
+    private fun sha(b: ByteArray) =
+        MessageDigest.getInstance("SHA-256").digest(b).joinToString("") { "%02x".format(it) }
+
+    private fun updateJson(version: Int, sha256: String, schema: Int = 1, sunset: String? = null): ByteArray {
+        val signed = JSONObject()
+            .put("schema", schema)
+            .put("version", version)
+            .put("sha256", sha256)
+            .put("build_date", "2026-06-13T00:00:00Z")
+        if (sunset != null) signed.put("sunset", sunset)
+        return JSONObject().put("signed", signed).toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private class FakeTransport : UpdateTransport {
+        val routes = mutableMapOf<String, Pair<Int, ByteArray>>()
+        val requested = mutableListOf<String>()
+        fun route(path: String, status: Int, body: ByteArray) { routes[path] = status to body }
+        override fun get(path: String): BhttpResponse {
+            requested += path
+            val (status, body) = routes[path] ?: (404 to ByteArray(0))
+            return BhttpResponse(status, emptyList(), body, emptyList())
+        }
+    }
+
+    private fun store() = IndicatorStore(tmp)
+
+    private fun seed(store: IndicatorStore, version: Int, sha256: String, bundle: ByteArray, objectCount: Int) {
+        store.writeBundle(bundle)
+        store.writeState(IndicatorStore.State(schema = 1, version = version, sha256 = sha256, objectCount = objectCount))
+    }
+
+    private fun fullPath(sha: String) = "/v1/$sha.json"
+    private fun deltaPath(from: Int, to: Int) = "/v1/deltas/delta-$from-$to.diff"
+
+    // --- tests -------------------------------------------------------------------------------------
+
+    @Test
+    fun freshInstall_downloadsFull() {
+        val store = store()
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(1, shaNew))
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t) { 1000L }.runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        out as IndicatorUpdater.Outcome.Updated
+        assertEquals(0, out.fromVersion)
+        assertEquals(1, out.toVersion)
+        assertFalse(out.viaDelta)
+        assertEquals(5, out.newObjects)
+        assertArrayEquals(newBundle, store.readBundle())
+        val s = store.readState()
+        assertEquals(1, s.version)
+        assertEquals(shaNew, s.sha256)
+        assertEquals(5, s.objectCount)
+        assertEquals(1000L, s.lastUpdateEpoch)
+    }
+
+    @Test
+    fun sameVersionAndHash_doesNothing() {
+        val store = store()
+        seed(store, version = 2, sha256 = shaNew, bundle = newBundle, objectCount = 5)
+        val t = FakeTransport().apply { route("/v1/update.json", 200, updateJson(2, shaNew)) }
+
+        val out = IndicatorUpdater(store, t) { 1234L }.runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.UpToDate)
+        // Only update.json was fetched; no full or delta.
+        assertEquals(listOf("/v1/update.json"), t.requested)
+        // lastCheck is bumped even on a no-op.
+        assertEquals(1234L, store.readState().lastCheckEpoch)
+    }
+
+    @Test
+    fun upToDate_usesStoredHashWithoutRecomputingLocalBundle() {
+        val store = store()
+        // On-disk bundle is garbage, but the stored hash matches the server: must NOT re-download.
+        store.writeBundle("not a real bundle".toByteArray())
+        store.writeState(IndicatorStore.State(schema = 1, version = 2, sha256 = shaNew, objectCount = 5))
+        val t = FakeTransport().apply { route("/v1/update.json", 200, updateJson(2, shaNew)) }
+
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.UpToDate)
+        assertEquals(listOf("/v1/update.json"), t.requested)
+    }
+
+    @Test
+    fun oneVersionAhead_appliesDelta() {
+        val store = store()
+        seed(store, version = 1, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(2, shaNew))
+            route(deltaPath(1, 2), 200, delta)
+            route(fullPath(shaNew), 200, newBundle) // fallback that must not be used
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        out as IndicatorUpdater.Outcome.Updated
+        assertTrue(out.viaDelta)
+        assertEquals(1, out.fromVersion)
+        assertEquals(2, out.toVersion)
+        assertArrayEquals(newBundle, store.readBundle())
+        assertEquals(shaNew, store.readState().sha256)
+        assertTrue(deltaPath(1, 2) in t.requested)
+        assertFalse(fullPath(shaNew) in t.requested)
+    }
+
+    @Test
+    fun deltaMissing_fallsBackToFull() {
+        val store = store()
+        seed(store, version = 1, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(2, shaNew))
+            // delta-1-2 intentionally absent -> 404
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
+        assertArrayEquals(newBundle, store.readBundle())
+        assertTrue(deltaPath(1, 2) in t.requested)
+        assertTrue(fullPath(shaNew) in t.requested)
+    }
+
+    @Test
+    fun deltaCorrupt_fallsBackToFull() {
+        val store = store()
+        seed(store, version = 1, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(2, shaNew))
+            route(deltaPath(1, 2), 200, "@@ -1,0 +1,1 @@\n+garbage".toByteArray()) // reconstructs wrong bytes
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
+        assertArrayEquals(newBundle, store.readBundle())
+    }
+
+    @Test
+    fun gapBeyondWindow_downloadsFullWithoutDelta() {
+        val store = store()
+        seed(store, version = 1, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(10, shaNew)) // gap of 9 > window of 5
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
+        assertFalse(t.requested.any { it.startsWith("/v1/deltas/") })
+    }
+
+    @Test
+    fun sameVersionHashMismatch_reDownloadsFull() {
+        val store = store()
+        // Same version locally, but a different hash than the feed advertises -> re-download.
+        seed(store, version = 2, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(2, shaNew))
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Updated)
+        assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
+        assertEquals(shaNew, store.readState().sha256)
+        assertArrayEquals(newBundle, store.readBundle())
+    }
+
+    @Test
+    fun unknownSchema_keepsLastGood() {
+        val store = store()
+        seed(store, version = 3, sha256 = shaOld, bundle = oldBundle, objectCount = 4)
+        val t = FakeTransport().apply { route("/v1/update.json", 200, updateJson(5, shaNew, schema = 2)) }
+
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.UnknownSchema)
+        assertEquals(2, (out as IndicatorUpdater.Outcome.UnknownSchema).schema)
+        // Local indicators untouched.
+        assertArrayEquals(oldBundle, store.readBundle())
+        assertEquals(3, store.readState().version)
+    }
+
+    @Test
+    fun fullHashMismatch_failsWithoutAdopting() {
+        val store = store()
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(1, shaNew))
+            route(fullPath(shaNew), 200, oldBundle) // body whose hash != advertised sha
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+
+        assertTrue(out is IndicatorUpdater.Outcome.Failed)
+        assertEquals(0, store.readState().version)
+        assertNull(store.readBundle())
+    }
+
+    @Test
+    fun updateJsonNotFound_fails() {
+        val t = FakeTransport() // update.json -> 404
+        val out = IndicatorUpdater(store(), t).runUpdate()
+        assertTrue(out is IndicatorUpdater.Outcome.Failed)
+    }
+
+    @Test
+    fun sunsetUpcoming_isReportedOnOutcome() {
+        val store = store()
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(1, shaNew, sunset = "2999-01-01"))
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+        assertTrue(out.sunset is SunsetStatus.Upcoming)
+        assertEquals("2999-01-01", store.readState().sunset)
+    }
+
+    @Test
+    fun sunsetReached_isReportedOnOutcome() {
+        val store = store()
+        val t = FakeTransport().apply {
+            route("/v1/update.json", 200, updateJson(1, shaNew, sunset = "2000-01-01"))
+            route(fullPath(shaNew), 200, newBundle)
+        }
+        val out = IndicatorUpdater(store, t).runUpdate()
+        assertTrue(out.sunset is SunsetStatus.Reached)
+    }
+}

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpFetchLiveTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpFetchLiveTest.kt
@@ -1,0 +1,39 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+
+/**
+ * Live end-to-end fetch from the real update server over Oblivious HTTP, including the HPKE round
+ * trip through the relay. Opt-in (network + external dependency), so it is skipped unless
+ * `BUGBANE_LIVE_OHTTP=1` is set:
+ *
+ *     BUGBANE_LIVE_OHTTP=1 ./gradlew :app:testProductionDebugUnitTest --tests '*OhttpFetchLiveTest*'
+ *
+ * It validates that the pinned key config is current, the relay/gateway are reachable, and the
+ * advertised full bundle is fetchable and hashes to `signed.sha256`.
+ */
+@EnabledIfEnvironmentVariable(named = "BUGBANE_LIVE_OHTTP", matches = "1")
+class OhttpFetchLiveTest {
+
+    @Test
+    fun fetchesUpdateJsonOverOhttp() {
+        val resp = OhttpTransport().get("/v1/update.json")
+        assertEquals(200, resp.statusCode)
+        val meta = UpdateMetadata.parse(resp.body)
+        assertEquals(IndicatorUpdater.SCHEMA, meta.schema)
+        assertTrue(meta.version >= 1)
+        assertEquals(64, meta.sha256.length)
+    }
+
+    @Test
+    fun fullBundleMatchesAdvertisedHash() {
+        val transport = OhttpTransport()
+        val meta = UpdateMetadata.parse(transport.get("/v1/update.json").body)
+        val full = transport.get("/v1/${meta.sha256}.json")
+        assertEquals(200, full.statusCode)
+        assertEquals(meta.sha256, OhttpTransport.sha256Hex(full.body))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,15 +12,17 @@ junitJupiter          = "5.13.4"
 protobuf              = "4.32.0"
 protobufPlugin        = "0.9.5"
 conscrypt             = "2.5.3"
-ahocorasick           = "0.6.3"
 libadb                = "3.0.0"
 sunSecurityAndroid    = "1.1"
 work                  = "2.10.3"
-snakeyaml             = "2.5"
+javaDiffUtils         = "4.15"
 kage                  = "0.3.0"
 json                  = "20250517"
 accompanist-permissions = "0.37.3"
 libmvt                = "0.0.3"
+libohttp              = "1.0.0"
+libohttpHpkeBc        = "1.0.1"
+libbhttp              = "1.0.0"
 
 [plugins]
 android-application   = { id = "com.android.application",            version.ref = "agp" }
@@ -50,13 +52,15 @@ google-accompanist-permissions = { module = "com.google.accompanist:accompanist-
 libadb-android                    = { group = "com.github.MuntashirAkon",    name = "libadb-android",         version.ref = "libadb" }
 sun-security-android              = { group = "com.github.MuntashirAkon",    name = "sun-security-android",   version.ref = "sunSecurityAndroid" }
 conscrypt-android                 = { group = "org.conscrypt",                name = "conscrypt-android",      version.ref = "conscrypt" }
-ahocorasick                       = { group = "org.ahocorasick",              name = "ahocorasick",            version.ref = "ahocorasick" }
 protobuf-javalite                 = { group = "com.google.protobuf",          name = "protobuf-javalite",      version.ref = "protobuf" }
 protoc                            = { group = "com.google.protobuf",          name = "protoc",                 version.ref = "protobuf" }
 junit-jupiter-api                 = { group = "org.junit.jupiter",            name = "junit-jupiter-api",      version.ref = "junitJupiter" }
 junit-jupiter-engine              = { group = "org.junit.jupiter",            name = "junit-jupiter-engine",   version.ref = "junitJupiter" }
 androidx-work-runtime-ktx         = { group = "androidx.work",              name = "work-runtime-ktx",      version.ref = "work" }
-snakeyaml                         = { group = "org.yaml",                   name = "snakeyaml",             version.ref = "snakeyaml" }
+java-diff-utils                   = { group = "io.github.java-diff-utils",  name = "java-diff-utils",       version.ref = "javaDiffUtils" }
 kage                              = { group = "com.github.android-password-store", name = "kage", version.ref = "kage" }
 org-json                          = { group = "org.json",                     name = "json",                   version.ref = "json" }
 libmvt                            = { group = "com.github.osservatorionessuno", name = "libmvt", version.ref = "libmvt" }
+libohttp                          = { group = "com.github.osservatorionessuno", name = "libohttp",         version.ref = "libohttp" }
+libohttp-hpke-bc                  = { group = "com.github.osservatorionessuno", name = "libohttp-hpke-bc", version.ref = "libohttpHpkeBc" }
+libbhttp                          = { group = "com.github.osservatorionessuno", name = "libbhttp",         version.ref = "libbhttp" }


### PR DESCRIPTION
Implements and refines what's described in https://github.com/osservatorionessuno/bugbane/issues/36

### Transport
We are using our own OHTTP library: [libohttp](https://github.com/osservatorionessuno/libohttp). It has to be used with other two components, a crypto backend for HPKE and a binary HTTP encoder/decoder. Most existing libraries bundle that in as a single file, however, we'd decided to avoid re-implementing a subset of HPKE, and similarly there could be a ready made binary HTTP library that we might use. [libohttp-hpke-bc](https://github.com/osservatorionessuno/libohttp-hpke-bc) provides a HPKE backend based on BouncyCastle, that we plan to use for crypto everywhere else anyway. On API level 37+, it is possible to use system HPKE, however it will be years before that is widespread enough to drop BC. [libbhttp](https://github.com/osservatorionessuno/libbhttp) is also pretty small. The reason for decoupling, is that one could use another encoder more closely tied to another HTTP, helper, such as Flo's [ok-bhttp](https://github.com/flohealth/ok-bhttp).

### Backend
I've deployed on my usual anycast server fleet [update.bugbane.org](https://update.bugbane.org) as a OHTTP gateway, with [oblivious.network ](https://oblivious.network) as an experimental relay. It's rewritten as an OpenResty module for nginx, and the gateway and the backend server are the same entity and can handle significant load even on the lowe end machines (3-4k requests per second). For convenience and debugging, the update files are exposed both via OHTTP and via plain HTTPS.

### Updater
[bugbane-updater](https://github.com/osservatorionessuno/bugbane-updater) is responsible for building the single IOC update file and its associated metadata, at `update.json`. The metadata contain the build time, the build version (which must be monotonic), and the hash and url of the build file (which is expected as `<sha256>.json`.

The current version can be seen here https://update.bugbane.org/v1/

The repository runs a periodic Github Action that fetches the MVT's indicators file, plus any additional one specified in the config file, and run the same logic as MVT (fetch the respective repository, get the associated files). It then does a single deterministic build, removing duplicates. It also creates (when possible) diff files from the previous 5 versions. The diff files are standard (and are applied via a standard Java diff lib) and are not signed: since the application of the patch is deterministic, clients can just has the full indicators at the end of the process and check that it matches the hash in the metadata. This save a significant amount of bw: the full file is currently ~8MB, while a diff could be a few KB. The process is automatic, and by versioning schema we can have an easier transition later. The metadata file is currently signed and logged via the Sigsum test log, but no signature is verified (yet) in app. The idea is to keep the indicators archived and ordered when we're gonna spend more time to make the process reproducible and have a solid forensic custody chain.

In the matadata file, there's also an optional `sunset` field. It will be used to tell the users a potential cutoff date if we ever migrated services or metadata for which they must update their app. 