### PR TITLE
Scan screen persistence

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/MainActivity.kt
@@ -32,7 +32,6 @@ import org.osservatorionessuno.bugbane.utils.AppState
 import org.osservatorionessuno.bugbane.utils.ConfigurationViewModel
 import org.osservatorionessuno.bugbane.utils.SlideshowManager
 import org.osservatorionessuno.bugbane.utils.ViewModelFactory
-import org.osservatorionessuno.cadb.AdbState
 
 private const val TAG = "MainActivity"
 class MainActivity : ComponentActivity() {
@@ -116,14 +115,6 @@ fun MainContent() {
     // Detect if we're in landscape mode
     val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
     
-    // Get adbState to check if scan is in progress
-    val application = context.applicationContext as android.app.Application
-    val viewModel = remember { ViewModelFactory.get(application) }
-    val adbState = viewModel.adbManager.adbState.collectAsStateWithLifecycle()
-    
-    // Temporary: Block swipe and acquisition tab while scan is being performed
-    val isScanning = adbState.value == AdbState.ConnectedAcquiring || adbState.value == AdbState.Cancelling
-    
     // Sync tab selection with pager
     val selectedTabIndex by remember { derivedStateOf { pagerState.currentPage } }
     
@@ -134,8 +125,6 @@ fun MainContent() {
                 MergedTopBar(
                     selectedTabIndex = selectedTabIndex,
                     onTabSelected = { tabIndex ->
-                        // Temporary: Block switching to acquisitions tab while scanning
-                        if (isScanning && tabIndex == 1) return@MergedTopBar
                         coroutineScope.launch {
                             pagerState.animateScrollToPage(tabIndex)
                         }
@@ -143,8 +132,7 @@ fun MainContent() {
                     onSettingsClick = {
                         val intent = Intent(context, SettingsActivity::class.java)
                         context.startActivity(intent)
-                    },
-                    isAcquisitionsTabDisabled = isScanning
+                    }
                 )
             } else {
                 // Portrait mode: separate top bar and navigation tabs
@@ -158,13 +146,10 @@ fun MainContent() {
                     NavigationTabs(
                         selectedTabIndex = selectedTabIndex,
                         onTabSelected = { tabIndex ->
-                            // Temporary: Block switching to acquisitions tab while scanning
-                            if (isScanning && tabIndex == 1) return@NavigationTabs
                             coroutineScope.launch {
                                 pagerState.animateScrollToPage(tabIndex)
                             }
-                        },
-                        isAcquisitionsTabDisabled = isScanning
+                        }
                     )
                 }
             }
@@ -178,9 +163,7 @@ fun MainContent() {
         ) {
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxSize(),
-                // Temporary: Block swipe while scan is being performed
-                userScrollEnabled = !isScanning
+                modifier = Modifier.fillMaxSize()
             ) { pageIndex ->
                 when (pageIndex) {
                     0 -> ScanScreen()

--- a/app/src/main/java/org/osservatorionessuno/bugbane/components/AppTopBar.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/components/AppTopBar.kt
@@ -65,7 +65,6 @@ fun MergedTopBar(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
     onSettingsClick: () -> Unit = {},
-    isAcquisitionsTabDisabled: Boolean = false // Temporary: Disable acquisitions tab while scanning
 ) {
     TopAppBar(
         title = {
@@ -94,8 +93,7 @@ fun MergedTopBar(
                 NavigationTabs(
                     selectedTabIndex = selectedTabIndex,
                     onTabSelected = onTabSelected,
-                    isLandscape = true,
-                    isAcquisitionsTabDisabled = isAcquisitionsTabDisabled
+                    isLandscape = true
                 )
                 IconButton(onClick = onSettingsClick) {
                     Icon(

--- a/app/src/main/java/org/osservatorionessuno/bugbane/components/NavigationTabs.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/components/NavigationTabs.kt
@@ -32,7 +32,6 @@ fun NavigationTabs(
     selectedTabIndex: Int,
     onTabSelected: (Int) -> Unit,
     isLandscape: Boolean = false,
-    isAcquisitionsTabDisabled: Boolean = false // Temporary: Disable acquisitions tab while scanning
 ) {
     val tabs = listOf(
         TabItem(stringResource(R.string.main_nav_scan), Icons.Default.Search),
@@ -47,7 +46,6 @@ fun NavigationTabs(
         ) {
             tabs.forEachIndexed { index, tab ->
                 val isSelected = selectedTabIndex == index
-                val isDisabled = index == 1 && isAcquisitionsTabDisabled // Temporary: Disable acquisitions tab (index 1)
                 Column(
                     horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
                     modifier = Modifier
@@ -57,13 +55,13 @@ fun NavigationTabs(
                             else androidx.compose.ui.graphics.Color.Transparent
                         )
                         .padding(horizontal = 12.dp, vertical = 8.dp)
-                        .clickable(enabled = !isDisabled) { onTabSelected(index) }
+                        .clickable { onTabSelected(index) }
                 ) {
                     Icon(
                         imageVector = tab.icon,
                         contentDescription = tab.title,
                         modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onPrimary.copy(alpha = if (isDisabled) 0.4f else 1f)
+                        tint = MaterialTheme.colorScheme.onPrimary
                     )
                     Spacer(modifier = Modifier.height(2.dp))
                     Text(
@@ -71,7 +69,7 @@ fun NavigationTabs(
                         style = MaterialTheme.typography.bodySmall.copy(
                             fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
                         ),
-                        color = MaterialTheme.colorScheme.onPrimary.copy(alpha = if (isDisabled) 0.4f else 1f)
+                        color = MaterialTheme.colorScheme.onPrimary
                     )
                 }
             }
@@ -99,12 +97,10 @@ fun NavigationTabs(
             }
         ) {
             tabs.forEachIndexed { index, tab ->
-                val isDisabled = index == 1 && isAcquisitionsTabDisabled // Temporary: Disable acquisitions tab (index 1)
                 Tab(
                     selected = selectedTabIndex == index,
                     onClick = { onTabSelected(index) },
-                    enabled = !isDisabled,
-                    text = { 
+                    text = {
                         Text(
                             text = tab.title,
                             style = MaterialTheme.typography.bodyMedium.copy(

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionDetailScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionDetailScreen.kt
@@ -72,6 +72,23 @@ fun AcquisitionDetailScreen(acquisitionDir: File) {
     var selectedScans by remember { mutableStateOf<Set<ScanSummary>>(emptySet()) }
     var showDeleteConfirmDialog by remember { mutableStateOf(false) }
 
+    // A fresh acquisition's first analysis starts automatically (see
+    // AcquisitionProgressTracker). Mirror it here as if the analyze button
+    // had been pressed, and load its results once it completes.
+    val autoAnalyzing =
+        org.osservatorionessuno.bugbane.utils.AcquisitionProgressTracker.analyzing.collectAsState()
+    var wasAutoAnalyzing by remember { mutableStateOf(false) }
+    LaunchedEffect(autoAnalyzing.value) {
+        if (autoAnalyzing.value?.absolutePath == acquisitionDir.absolutePath) {
+            wasAutoAnalyzing = true
+            processing = ProcessingState.SCANNING
+        } else if (wasAutoAnalyzing) {
+            wasAutoAnalyzing = false
+            scans = withContext(Dispatchers.IO) { loadScans(acquisitionDir) }
+            processing = ProcessingState.OFF
+        }
+    }
+
     LaunchedEffect(acquisitionDir) {
         size = Utils.calculateSize(acquisitionDir)
         val metaFile = File(acquisitionDir, "acquisition.json")

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.osservatorionessuno.bugbane.R
 import org.osservatorionessuno.bugbane.utils.ConfigurationManager
 import org.osservatorionessuno.bugbane.SlideshowActivity
@@ -32,10 +31,10 @@ import org.osservatorionessuno.bugbane.AcquisitionActivity
 import org.osservatorionessuno.bugbane.components.LayeredProgressIndicator
 import org.osservatorionessuno.bugbane.INTENT_EXIT_BACKPRESS
 import org.osservatorionessuno.cadb.AdbState
+import org.osservatorionessuno.bugbane.utils.AcquisitionProgressTracker
 import org.osservatorionessuno.bugbane.utils.AppState
 import org.osservatorionessuno.bugbane.utils.ViewModelFactory
 import org.osservatorionessuno.bugbane.utils.Utils
-import org.osservatorionessuno.qf.AcquisitionRunner
 import java.io.File
 
 private const val TAG = "ScanScreen"
@@ -43,7 +42,6 @@ private const val BETA_COUNTDOWN_SECONDS = 10
 
 @Composable
 fun ScanScreen() {
-    val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
     val application = LocalContext.current.applicationContext as Application
@@ -52,76 +50,36 @@ fun ScanScreen() {
     val appState = viewModel.configurationState.collectAsStateWithLifecycle()
     val adbManager = viewModel.adbManager
     val adbState = adbManager.adbState.collectAsStateWithLifecycle()
-    
-    var showDisableDialog by remember { mutableStateOf(false) }
-    var completedModules by remember { mutableStateOf(0) }
-    var totalModules by remember { mutableStateOf(0) }
-    val progressLogs = remember { mutableStateListOf<String>() }
-    val moduleLogIndex = remember { mutableStateMapOf<String, Int>() }
-    val moduleBytes = remember { mutableStateMapOf<String, Long>() }
-    
+
+    // Progress lives in an application-scoped tracker so it survives this
+    // screen (or the whole activity) being recreated mid-acquisition.
+    val modules = AcquisitionProgressTracker.modules.collectAsStateWithLifecycle()
+    val completedModules = AcquisitionProgressTracker.completedModules.collectAsStateWithLifecycle()
+    val totalModules = AcquisitionProgressTracker.totalModules.collectAsStateWithLifecycle()
+    val pendingAcquisition = AcquisitionProgressTracker.pendingAcquisition.collectAsStateWithLifecycle()
+    val showDisableDialog = AcquisitionProgressTracker.showDisableReminder.collectAsStateWithLifecycle()
+
     val isBetaVersion = context.packageName.contains("beta", ignoreCase = true)
     var showBetaWarningDialog by remember { mutableStateOf(false) }
     var betaCountdown by remember { mutableStateOf(BETA_COUNTDOWN_SECONDS) }
     var betaButtonEnabled by remember { mutableStateOf(false) }
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-    
+
     fun startAcquisition() {
-        val baseDir = File(context.filesDir, "acquisitions")
-        progressLogs.clear()
-        moduleLogIndex.clear()
-        moduleBytes.clear()
-        completedModules = 0
-        totalModules = 0
-        adbManager.runQuickForensics(baseDir, object : AcquisitionRunner.ProgressListener {
-            override fun onModuleStart(name: String, completed: Int, total: Int) {
-                coroutineScope.launch {
-                    totalModules = total
-                    moduleLogIndex[name] = progressLogs.size
-                    moduleBytes[name] = 0L
-                    progressLogs.add(context.getString(R.string.scan_module_running, name, Utils.formatBytes(0L)))
-                }
-            }
+        AcquisitionProgressTracker.start(context, adbManager, File(context.filesDir, "acquisitions"))
+    }
 
-            override fun onModuleProgress(name: String, bytes: Long) {
-                coroutineScope.launch {
-                    val idx = moduleLogIndex[name] ?: return@launch
-                    moduleBytes[name] = bytes
-                    progressLogs[idx] = context.getString(R.string.scan_module_running, name, Utils.formatBytes(bytes))
-                }
-            }
-
-            override fun onModuleComplete(name: String, completed: Int, total: Int) {
-                coroutineScope.launch {
-                    completedModules = completed
-                    val idx = moduleLogIndex[name]
-                    val finalBytes = moduleBytes[name] ?: 0L
-                    if (idx != null) {
-                        progressLogs[idx] = context.getString(R.string.scan_module_completed, name, Utils.formatBytes(finalBytes))
-                    } else {
-                        progressLogs.add(context.getString(R.string.scan_module_completed, name, Utils.formatBytes(finalBytes)))
-                    }
-                }
-            }
-
-            override fun isCancelled(): Boolean = adbManager.isQuickForensicsCancelled
-
-            override fun onFinished(cancelled: Boolean) {
-                coroutineScope.launch {
-                    if (!cancelled) {
-                        val latest = baseDir.listFiles()?.filter { it.isDirectory }?.maxByOrNull { it.lastModified() }
-                        if (latest != null) {
-                            val intent = Intent(context, AcquisitionActivity::class.java).apply {
-                                putExtra(AcquisitionActivity.EXTRA_PATH, latest.absolutePath)
-                            }
-                            context.startActivity(intent)
-                        }
-                        showDisableDialog = true
-                    }
-                }
-            }
-        })
+    // Navigate to a freshly finished acquisition. This also fires when the
+    // screen is recreated (or the app is reopened from the completion
+    // notification) while a finished acquisition is still pending.
+    LaunchedEffect(pendingAcquisition.value) {
+        val pending = pendingAcquisition.value ?: return@LaunchedEffect
+        AcquisitionProgressTracker.consumePendingAcquisition(context)
+        val intent = Intent(context, AcquisitionActivity::class.java).apply {
+            putExtra(AcquisitionActivity.EXTRA_PATH, pending.absolutePath)
+        }
+        context.startActivity(intent)
     }
 
     Column(
@@ -141,8 +99,8 @@ fun ScanScreen() {
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 LayeredProgressIndicator(
-                                    totalModules = totalModules,
-                                    completedModules = completedModules,
+                                    totalModules = totalModules.value,
+                                    completedModules = completedModules.value,
                                     size = 128.dp,
                                     strokeWidth = 8.dp
                                 )
@@ -154,8 +112,14 @@ fun ScanScreen() {
                                 .fillMaxHeight()
                                 .padding(16.dp),
                         ) {
-                            items(progressLogs) { log ->
-                                Text(log)
+                            items(modules.value) { module ->
+                                Text(
+                                    stringResource(
+                                        if (module.done) R.string.scan_module_completed else R.string.scan_module_running,
+                                        module.name,
+                                        Utils.formatBytes(module.bytes)
+                                    )
+                                )
                             }
                         }
                     }
@@ -169,8 +133,8 @@ fun ScanScreen() {
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 LayeredProgressIndicator(
-                                    totalModules = totalModules,
-                                    completedModules = completedModules,
+                                    totalModules = totalModules.value,
+                                    completedModules = completedModules.value,
                                     size = 128.dp,
                                     strokeWidth = 8.dp
                                 )
@@ -182,8 +146,14 @@ fun ScanScreen() {
                                 .fillMaxWidth()
                                 .padding(16.dp),
                         ) {
-                            items(progressLogs) { log ->
-                                Text(log)
+                            items(modules.value) { module ->
+                                Text(
+                                    stringResource(
+                                        if (module.done) R.string.scan_module_completed else R.string.scan_module_running,
+                                        module.name,
+                                        Utils.formatBytes(module.bytes)
+                                    )
+                                )
                             }
                         }
                     }
@@ -281,7 +251,7 @@ fun ScanScreen() {
                 }
 
                 // Disable Development Tools Dialog
-                if (showDisableDialog) {
+                if (showDisableDialog.value) {
                     Card(
                         modifier = Modifier
                             .align(Alignment.TopCenter)
@@ -310,7 +280,7 @@ fun ScanScreen() {
                                 Button(
                                     onClick = {
                                         ConfigurationManager.openDeveloperOptions(context)
-                                        showDisableDialog = false
+                                        AcquisitionProgressTracker.dismissDisableReminder()
                                     },
                                     colors = ButtonDefaults.buttonColors(
                                         containerColor = MaterialTheme.colorScheme.error
@@ -320,7 +290,7 @@ fun ScanScreen() {
                                 }
 
                                 IconButton(
-                                    onClick = { showDisableDialog = false }
+                                    onClick = { AcquisitionProgressTracker.dismissDisableReminder() }
                                 ) {
                                     Icon(
                                         imageVector = Icons.Default.Close,

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -1,0 +1,158 @@
+package org.osservatorionessuno.bugbane.utils
+
+import android.Manifest
+import android.app.ActivityManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.osservatorionessuno.bugbane.MainActivity
+import org.osservatorionessuno.bugbane.R
+import org.osservatorionessuno.cadb.AdbManager
+import org.osservatorionessuno.qf.AcquisitionRunner
+import java.io.File
+
+private const val TAG = "AcquisitionProgressTracker"
+
+/**
+ * Application-scoped holder for the progress of a running acquisition.
+ *
+ * The UI only renders these flows, so the progress display survives the
+ * hosting activity being recreated (e.g. after visiting settings or a
+ * configuration change) while the acquisition keeps running on the
+ * AdbManager executor.
+ *
+ * When the acquisition finishes while the app is not in the foreground, a
+ * notification is posted; tapping it reopens [MainActivity], where the
+ * pending acquisition is picked up and the results are shown.
+ */
+object AcquisitionProgressTracker {
+    private const val CHANNEL_ID = "acquisition_complete"
+    private const val NOTIFICATION_ID = 2
+
+    data class ModuleProgress(val name: String, val bytes: Long, val done: Boolean)
+
+    private val _modules = MutableStateFlow<List<ModuleProgress>>(emptyList())
+    val modules: StateFlow<List<ModuleProgress>> = _modules.asStateFlow()
+
+    private val _completedModules = MutableStateFlow(0)
+    val completedModules: StateFlow<Int> = _completedModules.asStateFlow()
+
+    private val _totalModules = MutableStateFlow(0)
+    val totalModules: StateFlow<Int> = _totalModules.asStateFlow()
+
+    /** A finished acquisition the UI has not navigated to yet. */
+    private val _pendingAcquisition = MutableStateFlow<File?>(null)
+    val pendingAcquisition: StateFlow<File?> = _pendingAcquisition.asStateFlow()
+
+    /** True after a successful acquisition until the user dismisses the reminder. */
+    private val _showDisableReminder = MutableStateFlow(false)
+    val showDisableReminder: StateFlow<Boolean> = _showDisableReminder.asStateFlow()
+
+    fun start(context: Context, adbManager: AdbManager, baseDir: File) {
+        val appContext = context.applicationContext
+        _modules.value = emptyList()
+        _completedModules.value = 0
+        _totalModules.value = 0
+        _pendingAcquisition.value = null
+
+        adbManager.runQuickForensics(baseDir, object : AcquisitionRunner.ProgressListener {
+            override fun onModuleStart(name: String, completed: Int, total: Int) {
+                _totalModules.value = total
+                _modules.update { it + ModuleProgress(name, 0L, false) }
+            }
+
+            override fun onModuleProgress(name: String, bytes: Long) {
+                _modules.update { list ->
+                    list.map { if (it.name == name && !it.done) it.copy(bytes = bytes) else it }
+                }
+            }
+
+            override fun onModuleComplete(name: String, completed: Int, total: Int) {
+                _completedModules.value = completed
+                _modules.update { list ->
+                    if (list.any { it.name == name }) {
+                        list.map { if (it.name == name) it.copy(done = true) else it }
+                    } else {
+                        list + ModuleProgress(name, 0L, true)
+                    }
+                }
+            }
+
+            override fun isCancelled(): Boolean = adbManager.isQuickForensicsCancelled
+
+            override fun onFinished(cancelled: Boolean, output: File?) {
+                if (cancelled || output == null) return
+                _showDisableReminder.value = true
+                _pendingAcquisition.value = output
+                if (!isAppInForeground()) {
+                    postFinishedNotification(appContext)
+                }
+            }
+        })
+    }
+
+    /** Called by the UI once it has navigated to the finished acquisition. */
+    fun consumePendingAcquisition(context: Context) {
+        _pendingAcquisition.value = null
+        NotificationManagerCompat.from(context.applicationContext).cancel(NOTIFICATION_ID)
+    }
+
+    fun dismissDisableReminder() {
+        _showDisableReminder.value = false
+    }
+
+    private fun isAppInForeground(): Boolean {
+        val state = ActivityManager.RunningAppProcessInfo()
+        ActivityManager.getMyMemoryState(state)
+        return state.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+    }
+
+    private fun postFinishedNotification(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "Notification permission missing, skipping completion notification")
+            return
+        }
+
+        val manager = NotificationManagerCompat.from(context)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.notification_channel_acquisition),
+                NotificationManager.IMPORTANCE_HIGH
+            )
+        )
+
+        // Reopen the app; ScanScreen consumes the pending acquisition and
+        // navigates to the results.
+        val intent = Intent(context, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        val pendingIntent = PendingIntent.getActivity(
+            context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bugbane_zoom)
+            .setContentTitle(context.getString(R.string.notification_acquisition_complete_title))
+            .setContentText(context.getString(R.string.notification_acquisition_complete_text))
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -12,14 +12,19 @@ import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import org.osservatorionessuno.bugbane.MainActivity
 import org.osservatorionessuno.bugbane.R
 import org.osservatorionessuno.cadb.AdbManager
 import org.osservatorionessuno.qf.AcquisitionRunner
+import org.osservatorionessuno.qf.AcquisitionScanner
 import java.io.File
 
 private const val TAG = "AcquisitionProgressTracker"
@@ -59,6 +64,12 @@ object AcquisitionProgressTracker {
     private val _showDisableReminder = MutableStateFlow(false)
     val showDisableReminder: StateFlow<Boolean> = _showDisableReminder.asStateFlow()
 
+    /** The acquisition directory whose first analysis is currently running. */
+    private val _analyzing = MutableStateFlow<File?>(null)
+    val analyzing: StateFlow<File?> = _analyzing.asStateFlow()
+
+    private val analysisScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     fun start(context: Context, adbManager: AdbManager, baseDir: File) {
         val appContext = context.applicationContext
         _modules.value = emptyList()
@@ -95,11 +106,32 @@ object AcquisitionProgressTracker {
                 if (cancelled || output == null) return
                 _showDisableReminder.value = true
                 _pendingAcquisition.value = output
-                if (!isAppInForeground()) {
-                    postFinishedNotification(appContext)
-                }
+                autoAnalyze(appContext, output)
             }
         })
+    }
+
+    /**
+     * Run the first analysis automatically. When the app is in the
+     * background the completion notification is deferred until the analysis
+     * is done, so tapping it lands on the results.
+     */
+    private fun autoAnalyze(context: Context, acquisitionDir: File) {
+        _analyzing.value = acquisitionDir
+        analysisScope.launch {
+            var analyzed = false
+            try {
+                AcquisitionScanner.scan(context, acquisitionDir)
+                analyzed = true
+            } catch (t: Throwable) {
+                Log.e(TAG, "Automatic analysis failed", t)
+            } finally {
+                _analyzing.value = null
+            }
+            if (!isAppInForeground()) {
+                postFinishedNotification(context, analyzed)
+            }
+        }
     }
 
     /** Called by the UI once it has navigated to the finished acquisition. */
@@ -118,7 +150,7 @@ object AcquisitionProgressTracker {
         return state.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 
-    private fun postFinishedNotification(context: Context) {
+    private fun postFinishedNotification(context: Context, analyzed: Boolean) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
         ) {
@@ -147,7 +179,12 @@ object AcquisitionProgressTracker {
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_bugbane_zoom)
             .setContentTitle(context.getString(R.string.notification_acquisition_complete_title))
-            .setContentText(context.getString(R.string.notification_acquisition_complete_text))
+            .setContentText(
+                context.getString(
+                    if (analyzed) R.string.notification_acquisition_complete_analyzed_text
+                    else R.string.notification_acquisition_complete_text
+                )
+            )
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
@@ -76,7 +76,7 @@ class AcquisitionRunner(
         fun onModuleProgress(name: String, bytes: Long)
         fun onModuleComplete(name: String, completed: Int, total: Int)
         fun isCancelled(): Boolean
-        fun onFinished(cancelled: Boolean)
+        fun onFinished(cancelled: Boolean, output: File?)
     }
 
     /**
@@ -178,7 +178,7 @@ class AcquisitionRunner(
         }
 
         Log.i(TAG, "Acquisition complete in ${acquisitionDir.absolutePath}")
-        listener?.onFinished(false)
+        listener?.onFinished(cancelled, acquisitionDir)
         return acquisitionDir
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -206,4 +206,9 @@
     <string name="mvt_dumpsys_receivers_intercept_data_sms_title">Found a receiver to intercept incoming data SMS messages: %1$s</string>
     <string name="mvt_dumpsys_receivers_intercept_phone_state_title">Found a receiver monitoring telephony state/incoming calls: %1$s</string>
     <string name="mvt_dumpsys_receivers_intercept_outgoing_call_title">Found a receiver monitoring outgoing calls: %1$s</string>
+
+    <!-- Acquisition completion notification -->
+    <string name="notification_channel_acquisition">Acquisitions</string>
+    <string name="notification_acquisition_complete_title">Acquisition complete</string>
+    <string name="notification_acquisition_complete_text">Tap to view the results</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,4 +211,5 @@
     <string name="notification_channel_acquisition">Acquisitions</string>
     <string name="notification_acquisition_complete_title">Acquisition complete</string>
     <string name="notification_acquisition_complete_text">Tap to view the results</string>
+    <string name="notification_acquisition_complete_analyzed_text">Analysis finished. Tap to view the results</string>
 </resources>


### PR DESCRIPTION
Currently, if the user navigates to the menu or away and goes back to the scanning screen, most information is lost and it looks buggy (though the scan continue). There's a bunch of separate fixes and improvements here:
 - Track the acquisition progress in a dedicated class, so we can rebuild the interface on demand
 - Automatically perform the analysis on new acquisitions
 - If the app in is the background, send a notification when the analysis is completed

I think this would give a less buggy feeling to the app, and avoid forcing the user to stay on the app while a scan is ongoing (it would have continued before too, but without notification).