### PR TITLE
Add email reporting with ACRA

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.junit5)
     alias(libs.plugins.protobuf)
-    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -130,6 +129,12 @@ val checkBundledIndicators by tasks.registering {
 }
 tasks.named("preBuild") { dependsOn(checkBundledIndicators) }
 
+// The ACRA modules leak the auto-service annotation processor onto the
+// runtime classpath; their service files are pre-generated, so drop it.
+configurations.all {
+    exclude(group = "com.google.auto.service", module = "auto-service")
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -167,7 +172,6 @@ dependencies {
     implementation(libs.acra.core)
     implementation(libs.acra.mail)
     implementation(libs.acra.notification)
-    kapt(libs.acra.core)
 
     // --- Unit test (JUnit 5) ---
     testImplementation(libs.junit.jupiter.api)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.junit5)
     alias(libs.plugins.protobuf)
+    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -18,6 +19,7 @@ android {
         versionCode = 5
         versionName = "0.1.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "CRASH_REPORT_EMAIL", "\"bugbane@osservatorionessuno.org\"")
     }
 
     flavorDimensions += "version"
@@ -36,7 +38,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("boolean", "CRASH_REPORTING_ENABLED", "false")
+        }
         release {
+            buildConfigField("boolean", "CRASH_REPORTING_ENABLED", "true")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -156,6 +162,12 @@ dependencies {
 
     // Tombstone protobuf (lite)
     implementation(libs.protobuf.javalite)
+
+    // Crash reporting (ACRA: mail sender + status-bar notification)
+    implementation(libs.acra.core)
+    implementation(libs.acra.mail)
+    implementation(libs.acra.notification)
+    kapt(libs.acra.core)
 
     // --- Unit test (JUnit 5) ---
     testImplementation(libs.junit.jupiter.api)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,7 +32,3 @@
 -keepclasseswithmembers class * implements org.apache.commons.compress.archivers.zip.ZipExtraField {
     <init>();
 }
-
-# ACRA kapt pulls compile-only annotation processor classes into R8's classpath.
--dontwarn javax.annotation.processing.AbstractProcessor
--dontwarn javax.annotation.processing.SupportedOptions

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,3 +32,7 @@
 -keepclasseswithmembers class * implements org.apache.commons.compress.archivers.zip.ZipExtraField {
     <init>();
 }
+
+# ACRA kapt pulls compile-only annotation processor classes into R8's classpath.
+-dontwarn javax.annotation.processing.AbstractProcessor
+-dontwarn javax.annotation.processing.SupportedOptions

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <!-- Currently used only to fetch IOCs -->
     <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:name=".BugbaneApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/org/osservatorionessuno/bugbane/BugbaneApplication.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/BugbaneApplication.kt
@@ -1,0 +1,62 @@
+package org.osservatorionessuno.bugbane
+
+import android.app.Application
+import org.acra.ReportField
+import org.acra.config.mailSenderConfiguration
+import org.acra.config.notificationConfiguration
+import org.acra.data.StringFormat
+import org.acra.ktx.initAcra
+import org.osservatorionessuno.bugbane.utils.ViewModelFactory
+
+class BugbaneApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        if (BuildConfig.CRASH_REPORTING_ENABLED) {
+            initAcra {
+                buildConfigClass = BuildConfig::class.java
+                alsoReportToAndroidFramework = false
+                reportFormat = StringFormat.KEY_VALUE_LIST
+                logcatArguments = listOf("-t", "200", "-v", "time")
+                reportContent = listOf(
+                    ReportField.APP_VERSION_CODE,
+                    ReportField.APP_VERSION_NAME,
+                    ReportField.ANDROID_VERSION,
+                    ReportField.PHONE_MODEL,
+                    ReportField.BRAND,
+                    ReportField.PRODUCT,
+                    ReportField.DEVICE_FEATURES,
+                    ReportField.STACK_TRACE,
+                    ReportField.LOGCAT,
+                    ReportField.USER_CRASH_DATE,
+                    ReportField.USER_APP_START_DATE,
+                    ReportField.AVAILABLE_MEM_SIZE,
+                    ReportField.TOTAL_MEM_SIZE,
+                    ReportField.BUILD,
+                    ReportField.BUILD_CONFIG,
+                    ReportField.INSTALLATION_ID,
+                )
+                pluginConfigurations = listOf(
+                    mailSenderConfiguration {
+                        mailTo = BuildConfig.CRASH_REPORT_EMAIL
+                        reportAsFile = true
+                        reportFileName = "bugbane_crash.txt"
+                        subject = getString(R.string.crash_report_mail_subject)
+                        body = getString(R.string.crash_report_mail_body)
+                    },
+                    notificationConfiguration {
+                        channelName = getString(R.string.notification_channel_crash)
+                        channelDescription = getString(R.string.crash_notification_channel_desc)
+                        title = getString(R.string.crash_notification_title)
+                        text = getString(R.string.crash_notification_text)
+                        tickerText = getString(R.string.crash_notification_ticker)
+                        resIcon = R.drawable.ic_bugbane_foreground
+                    },
+                )
+            }
+        }
+
+        ViewModelFactory.get(this)
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/BugbaneApplication.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/BugbaneApplication.kt
@@ -1,17 +1,19 @@
 package org.osservatorionessuno.bugbane
 
 import android.app.Application
+import android.content.Context
 import org.acra.ReportField
 import org.acra.config.mailSenderConfiguration
 import org.acra.config.notificationConfiguration
 import org.acra.data.StringFormat
 import org.acra.ktx.initAcra
-import org.osservatorionessuno.bugbane.utils.ViewModelFactory
 
 class BugbaneApplication : Application() {
 
-    override fun onCreate() {
-        super.onCreate()
+    // ACRA is initialized here rather than in onCreate so crashes during
+    // ContentProvider startup (androidx.startup, WorkManager) are reported.
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
 
         if (BuildConfig.CRASH_REPORTING_ENABLED) {
             initAcra {
@@ -56,7 +58,5 @@ class BugbaneApplication : Application() {
                 )
             }
         }
-
-        ViewModelFactory.get(this)
     }
 }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -55,6 +55,13 @@
     <string name="settings_indicators_count">File indicatori: %1$s</string>
     <string name="notification_channel_indicators">Indicatori</string>
     <string name="notification_indicators_updated">Scaricati %1$d nuovi indicatori</string>
+    <string name="notification_channel_crash">Segnalazioni crash</string>
+    <string name="crash_notification_channel_desc">Mostrata quando Bugbane va in crash, per inviare una segnalazione agli sviluppatori.</string>
+    <string name="crash_notification_title">Bugbane si è arrestato</string>
+    <string name="crash_notification_text">Tocca per inviare una segnalazione via email.</string>
+    <string name="crash_notification_ticker">Bugbane si è arrestato — tocca per inviare una segnalazione</string>
+    <string name="crash_report_mail_subject">Segnalazione crash Bugbane</string>
+    <string name="crash_report_mail_body">In allegato trovi la segnalazione del crash. Descrivi cosa stavi facendo quando l\'app si è arrestata.</string>
     <string name="acquisitions_title">Acquisizioni</string>
     <string name="acquisitions_rename">Rinomina</string>
     <string name="acquisitions_delete">Elimina</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,15 @@
     <string name="notification_channel_indicators">Indicators</string>
     <string name="notification_indicators_updated">Downloaded %1$d new indicators</string>
 
+    <!-- Crash report notification (ACRA) -->
+    <string name="notification_channel_crash">Crash reports</string>
+    <string name="crash_notification_channel_desc">Shown when Bugbane crashes so you can send a report to the developers.</string>
+    <string name="crash_notification_title">Bugbane crashed</string>
+    <string name="crash_notification_text">Tap to send a crash report by email.</string>
+    <string name="crash_notification_ticker">Bugbane crashed — tap to send a report</string>
+    <string name="crash_report_mail_subject">Bugbane crash report</string>
+    <string name="crash_report_mail_body">A crash report is attached. Please describe what you were doing when the app crashed.</string>
+
     <!-- Acquisitions screen strings -->
     <string name="acquisitions_title">Acquisitions</string>
     <string name="acquisitions_rename">Rename</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,10 +20,12 @@ libmvt                = "c8415cd719"
 libohttp              = "1.1.0"
 libohttpHpkeBc        = "1.0.1"
 libbhttp              = "1.1.0"
+acra                  = "5.13.1"
 
 [plugins]
 android-application   = { id = "com.android.application",            version.ref = "agp" }
 kotlin-android        = { id = "org.jetbrains.kotlin.android",       version.ref = "kotlin" }
+kotlin-kapt           = { id = "org.jetbrains.kotlin.kapt",          version.ref = "kotlin" }
 kotlin-jvm            = { id = "org.jetbrains.kotlin.jvm",           version.ref = "kotlin" }
 kotlin-compose        = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 junit5                = { id = "de.mannodermaus.android-junit5",     version = "1.13.1.0" }
@@ -59,3 +61,6 @@ libmvt                            = { group = "com.github.osservatorionessuno", 
 libohttp                          = { group = "com.github.osservatorionessuno", name = "libohttp",         version.ref = "libohttp" }
 libohttp-hpke-bc                  = { group = "com.github.osservatorionessuno", name = "libohttp-hpke-bc", version.ref = "libohttpHpkeBc" }
 libbhttp                          = { group = "com.github.osservatorionessuno", name = "libbhttp",         version.ref = "libbhttp" }
+acra-core                         = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
+acra-mail                         = { group = "ch.acra", name = "acra-mail", version.ref = "acra" }
+acra-notification                 = { group = "ch.acra", name = "acra-notification", version.ref = "acra" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ acra                  = "5.13.1"
 [plugins]
 android-application   = { id = "com.android.application",            version.ref = "agp" }
 kotlin-android        = { id = "org.jetbrains.kotlin.android",       version.ref = "kotlin" }
-kotlin-kapt           = { id = "org.jetbrains.kotlin.kapt",          version.ref = "kotlin" }
 kotlin-jvm            = { id = "org.jetbrains.kotlin.jvm",           version.ref = "kotlin" }
 kotlin-compose        = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 junit5                = { id = "de.mannodermaus.android-junit5",     version = "1.13.1.0" }


### PR DESCRIPTION
This PR implements #55.

ACRA is being used to collect logs after a crash and send a notification to the user that Bugbane crashed.
From the notification the user can send the crash log via email if they have an email client setup.
If the log cannot be sent due to an issue, on the next application launch the user will be prompted again to share the log.

Error log do not contain sensitive info, are sent only on an opt-in basis, manually and via email attachments to preserve user's privacy.