### PR TITLE
Adb CVE warning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,15 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Currently used only to fetch IOCs -->
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Package visibility (Android 11+): needed to read the Mainline train date
+         (modulemetadata versionName) for the ADB vulnerability check. -->
+    <queries>
+        <package android:name="com.google.android.modulemetadata" />
+        <package android:name="com.google.android.adbd" />
+        <package android:name="com.android.adbd" />
+    </queries>
+
     <application
         android:name=".BugbaneApplication"
         android:allowBackup="true"

--- a/app/src/main/java/org/osservatorionessuno/bugbane/SlideshowActivity.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/SlideshowActivity.kt
@@ -30,6 +30,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.flow.collectLatest
+import org.osservatorionessuno.bugbane.components.AdbVulnerabilityWarningPage
 import org.osservatorionessuno.bugbane.components.SlideshowPage
 import org.osservatorionessuno.bugbane.ui.theme.Theme
 import org.osservatorionessuno.bugbane.utils.AppState
@@ -203,13 +204,19 @@ fun SlideshowScreen(
             modifier = Modifier.weight(1f),
             userScrollEnabled = false
         ) { pageIndex ->
-            SlideshowPage(
-                state = state.value,
-                onClickContinue = {
-                    Log.d(TAG, "onClickContinue with state $state")
-                    viewModel.onChangeStateRequest(state.value)
-                }
-            )
+            if (state.value == AppState.NeedAdbVulnerabilityWarning) {
+                AdbVulnerabilityWarningPage(
+                    onContinue = { viewModel.onChangeStateRequest(state.value) }
+                )
+            } else {
+                SlideshowPage(
+                    state = state.value,
+                    onClickContinue = {
+                        Log.d(TAG, "onClickContinue with state $state")
+                        viewModel.onChangeStateRequest(state.value)
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/components/AdbVulnerabilityWarningPage.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/components/AdbVulnerabilityWarningPage.kt
@@ -1,0 +1,110 @@
+package org.osservatorionessuno.bugbane.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.osservatorionessuno.bugbane.R
+import org.osservatorionessuno.bugbane.security.SystemUpdateRedirect
+
+/**
+ * Shown during onboarding — only on devices still exposed to the wireless-ADB
+ * bypass (CVE-2026-0073) — right before debugging is enabled. Since bugbane is
+ * about to turn on wireless debugging (the exploit's precondition), it warns the
+ * user to update, and, if they proceed unpatched, to do so only on a trusted
+ * network / personal hotspot. Styled to match [SlideshowPage].
+ *
+ * [onContinue] proceeds with onboarding (the user acknowledges the risk).
+ */
+@Composable
+fun AdbVulnerabilityWarningPage(onContinue: () -> Unit) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Warning,
+            contentDescription = null,
+            modifier = Modifier
+                .size(80.dp)
+                .padding(bottom = 24.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+
+        Text(
+            text = stringResource(R.string.adb_vuln_title),
+            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold, fontSize = 24.sp),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.adb_vuln_description),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(R.string.adb_vuln_network_warning),
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.error,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = { SystemUpdateRedirect.open(context) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp, vertical = 4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = Color.White,
+            ),
+        ) {
+            Text(
+                text = stringResource(R.string.adb_vuln_update_button),
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+            )
+        }
+
+        OutlinedButton(
+            onClick = onContinue,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp, vertical = 4.dp),
+        ) {
+            Text(stringResource(R.string.adb_vuln_continue_button))
+        }
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/security/AdbExposureNotifier.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/security/AdbExposureNotifier.kt
@@ -1,0 +1,91 @@
+package org.osservatorionessuno.bugbane.security
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import org.osservatorionessuno.bugbane.R
+
+/**
+ * Ongoing notification for the exploitable window of CVE-2026-0073.
+ *
+ * It appears while a vulnerable device has Wireless Debugging switched on and no
+ * acquisition is running — i.e. the device is needlessly reachable over the
+ * network — and **auto-clears the moment Wireless Debugging is turned off**, so
+ * it never lingers once the user has closed the hole. An app cannot toggle the
+ * setting itself, so the tap action deep-links to Developer Options.
+ *
+ * Driven from [org.osservatorionessuno.bugbane.utils.ConfigurationViewModel],
+ * which already observes the wireless-debugging and ADB state; call [update]
+ * whenever those change.
+ */
+object AdbExposureNotifier {
+    private const val CHANNEL_ID = "adb_exposure"
+    private const val NOTIFICATION_ID = 3
+
+    fun update(
+        context: Context,
+        vulnerable: Boolean,
+        wirelessDebuggingOn: Boolean,
+        acquiring: Boolean,
+        onboardingComplete: Boolean,
+    ) {
+        val app = context.applicationContext
+        val manager = NotificationManagerCompat.from(app)
+
+        // Only nag once the exposure is gratuitous: device unpatched, wireless
+        // debugging on, not mid-acquisition, and past onboarding (which is when
+        // the user is deliberately enabling debugging).
+        val expose = vulnerable && wirelessDebuggingOn && !acquiring && onboardingComplete
+        if (!expose) {
+            manager.cancel(NOTIFICATION_ID)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            app.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return // no permission — the in-app banner covers this case
+        }
+
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                app.getString(R.string.notification_channel_adb_exposure),
+                NotificationManager.IMPORTANCE_HIGH,
+            ),
+        )
+
+        val settingsIntent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val pending = PendingIntent.getActivity(
+            app, 0, settingsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val text = app.getString(R.string.adb_exposure_notification_text)
+        val notification = NotificationCompat.Builder(app, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bugbane_zoom)
+            .setContentTitle(app.getString(R.string.adb_exposure_notification_title))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setOngoing(true)
+            .setContentIntent(pending)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .build()
+
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+
+    /** Clear the notification (e.g. on sign-out/reset). */
+    fun clear(context: Context) =
+        NotificationManagerCompat.from(context.applicationContext).cancel(NOTIFICATION_ID)
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/security/DeviceVulnerabilityChecker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/security/DeviceVulnerabilityChecker.kt
@@ -1,0 +1,113 @@
+package org.osservatorionessuno.bugbane.security
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+/** Outcome of checking one [VulnerabilityAdvisory] against the current device. */
+enum class VulnerabilityStatus {
+    /** The CVE doesn't apply to this device's Android version. */
+    NOT_APPLICABLE,
+
+    /** A fix is confirmed present (patched platform, or a Mainline train at/after the fix). */
+    PROTECTED,
+
+    /** Both channels are confirmed older than the fix. */
+    AT_RISK,
+
+    /** A signal is unreadable (non-GMS, no modulemetadata) — can't confirm; treat as needing action. */
+    UNDETERMINED,
+}
+
+data class AdvisoryReport(
+    val advisory: VulnerabilityAdvisory,
+    val status: VulnerabilityStatus,
+    val securityPatch: String?,
+    val mainlineTrain: String?,
+)
+
+/**
+ * Decides whether the device carries the adbd fix from two SDK-independent dates:
+ * the platform security patch level and the Mainline train date (the "Google Play
+ * system update" date carried by `com.google.android.modulemetadata`'s
+ * versionName). Reading is best-effort; missing signals yield
+ * [VulnerabilityStatus.UNDETERMINED] rather than a false clear.
+ */
+object DeviceVulnerabilityChecker {
+
+    private const val MODULE_METADATA_PACKAGE = "com.google.android.modulemetadata"
+    private val PATCH_FORMAT = Regex("""\d{4}-\d{2}-\d{2}""")
+    private val TRAIN_PREFIX = Regex("""\d{4}-\d{2}""")
+
+    /** Platform security patch level (YYYY-MM-DD), or null if absent/malformed. */
+    fun securityPatch(): String? =
+        Build.VERSION.SECURITY_PATCH?.takeIf { PATCH_FORMAT.matches(it) }
+
+    /**
+     * Mainline train as YYYY-MM (e.g. "2026-05"), from modulemetadata's versionName
+     * ("2026-05-01S+", "2026-03", …). Null if the module isn't present/readable.
+     */
+    fun mainlineTrain(context: Context): String? {
+        val name = runCatching {
+            context.packageManager.getPackageInfo(MODULE_METADATA_PACKAGE, 0).versionName
+        }.getOrNull() ?: return null
+        return TRAIN_PREFIX.find(name)?.value
+    }
+
+    fun check(context: Context, advisory: VulnerabilityAdvisory): AdvisoryReport {
+        val patch = securityPatch()
+        val train = mainlineTrain(context)
+        return AdvisoryReport(
+            advisory = advisory,
+            status = evaluate(Build.VERSION.SDK_INT, patch, train, advisory),
+            securityPatch = patch,
+            mainlineTrain = train,
+        )
+    }
+
+    /** Reports for all advisories that are not [VulnerabilityStatus.NOT_APPLICABLE]. */
+    fun applicableReports(context: Context): List<AdvisoryReport> =
+        Advisories.ALL.map { check(context, it) }.filter { it.status != VulnerabilityStatus.NOT_APPLICABLE }
+
+    @Volatile
+    private var atRiskCache: Boolean? = null
+
+    /**
+     * True if any applicable advisory is unresolved (at risk or unconfirmed).
+     * Cached — the device's Android version, patch level and Mainline train are
+     * fixed for the process lifetime, and this is polled from the state machine.
+     */
+    fun isAtRisk(context: Context): Boolean {
+        atRiskCache?.let { return it }
+        val result = applicableReports(context).any {
+            it.status == VulnerabilityStatus.AT_RISK || it.status == VulnerabilityStatus.UNDETERMINED
+        }
+        atRiskCache = result
+        return result
+    }
+
+    /**
+     * Pure evaluation — no Android dependencies. YYYY-MM-DD and YYYY-MM strings
+     * compare correctly lexicographically.
+     */
+    fun evaluate(
+        sdkInt: Int,
+        securityPatch: String?,
+        mainlineTrain: String?,
+        advisory: VulnerabilityAdvisory,
+    ): VulnerabilityStatus {
+        if (sdkInt < advisory.minAffectedSdk || sdkInt > advisory.maxAffectedSdk) {
+            return VulnerabilityStatus.NOT_APPLICABLE
+        }
+        if (securityPatch != null && securityPatch >= advisory.fixedSecurityPatch) {
+            return VulnerabilityStatus.PROTECTED
+        }
+        if (mainlineTrain != null && mainlineTrain >= advisory.fixedTrain) {
+            return VulnerabilityStatus.PROTECTED
+        }
+        // Platform patch is old (or unknown). If the Mainline train is readable and
+        // also old, both channels lack the fix → at risk. If it's unreadable, we
+        // can't confirm the Mainline side → undetermined (still needs action).
+        return if (mainlineTrain != null) VulnerabilityStatus.AT_RISK else VulnerabilityStatus.UNDETERMINED
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/security/SystemUpdateRedirect.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/security/SystemUpdateRedirect.kt
@@ -1,0 +1,37 @@
+package org.osservatorionessuno.bugbane.security
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+/**
+ * Sends the user to where they can apply updates. On GMS devices
+ * [Settings.ACTION_SYSTEM_UPDATE_SETTINGS] opens the GMS system-update screen,
+ * which covers both the OS security update and the Google Play system update
+ * (the adbd Mainline channel). Falls back to Security, then top-level Settings.
+ *
+ * Note: an app cannot query whether an OEM update is actually pending —
+ * `SystemUpdateManager.retrieveSystemUpdateInfo()` needs the privileged
+ * `READ_SYSTEM_UPDATE_INFO` permission — so we can only take the user there.
+ */
+object SystemUpdateRedirect {
+    // Not a public Settings constant — the action string resolves to the GMS
+    // SystemUpdateActivity on Play devices.
+    private const val ACTION_SYSTEM_UPDATE_SETTINGS = "android.settings.SYSTEM_UPDATE_SETTINGS"
+
+    fun open(context: Context): Boolean {
+        val candidates = listOf(
+            Intent(ACTION_SYSTEM_UPDATE_SETTINGS),
+            Intent(Settings.ACTION_SECURITY_SETTINGS),
+            Intent(Settings.ACTION_SETTINGS),
+        )
+        for (intent in candidates) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            if (intent.resolveActivity(context.packageManager) != null) {
+                context.startActivity(intent)
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/security/VulnerabilityAdvisory.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/security/VulnerabilityAdvisory.kt
@@ -1,0 +1,49 @@
+package org.osservatorionessuno.bugbane.security
+
+/**
+ * A device-vulnerability advisory bugbane can warn about. Plain data (no Android
+ * types) so the evaluation is unit-testable and the list could later be delivered
+ * through the signed update feed instead of being hardcoded.
+ *
+ * The fix is expressed as two **dates**, not version codes: the platform
+ * [fixedSecurityPatch] level and the Mainline [fixedTrain] (the "Google Play
+ * system update" date carried by `com.google.android.modulemetadata`). Both are
+ * SDK-independent and directly comparable — unlike the adbd APEX versionCode,
+ * which is per-SDK-lineage (`34…`/`36…`/`37…`) and therefore useless as a single
+ * threshold.
+ */
+data class VulnerabilityAdvisory(
+    val id: String,
+    val infoUrl: String,
+    /** Inclusive SDK range that was originally vulnerable (others: not applicable). */
+    val minAffectedSdk: Int,
+    val maxAffectedSdk: Int,
+    /** Platform security patch level containing the fix (YYYY-MM-DD). */
+    val fixedSecurityPatch: String,
+    /** First Mainline train (YYYY-MM) containing the fix. */
+    val fixedTrain: String,
+)
+
+/**
+ * Hardcoded advisories. Only the wireless-ADB authentication bypass
+ * (CVE-2026-0073): a logic error in adbd's mutual-TLS certificate check lets an
+ * attacker on the same network open a shell with no user interaction. Fixed at
+ * the 2026-05-01 security patch level and in the 2026-05 Mainline train; affects
+ * Android 14–16-qpr2 (API 34–36).
+ *
+ * NOTE: [fixedTrain] is a placeholder pending confirmation of the exact first
+ * fixed train (see the module-version investigation); 2026-05 matches the
+ * bulletin's stated fix month. Refine when confirmed.
+ */
+object Advisories {
+    val ADB_WIRELESS_BYPASS = VulnerabilityAdvisory(
+        id = "CVE-2026-0073",
+        infoUrl = "https://nvd.nist.gov/vuln/detail/CVE-2026-0073",
+        minAffectedSdk = 34,
+        maxAffectedSdk = 36,
+        fixedSecurityPatch = "2026-05-01",
+        fixedTrain = "2026-05",
+    )
+
+    val ALL: List<VulnerabilityAdvisory> = listOf(ADB_WIRELESS_BYPASS)
+}

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AppState.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AppState.kt
@@ -9,6 +9,10 @@ enum class AppState(val step: Int) {
     NeedNotificationPermission(1),
     DeviceUnsupported(1), // Alternative to step 1: device isn't compatible
     NeedWifi(2),
+    // Shown before developer options, only on devices still exposed to the
+    // wireless-ADB bypass (CVE-2026-0073). Shares step 3 so it adds no extra
+    // progress dot for unaffected users who never see it.
+    NeedAdbVulnerabilityWarning(3),
     NeedDeveloperOptions(3),
 
     // Step 4: ADB/Wireless ADB/Pairing

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.osservatorionessuno.bugbane.MainActivity
+import org.osservatorionessuno.bugbane.security.DeviceVulnerabilityChecker
 import org.osservatorionessuno.cadb.AdbManager
 import org.osservatorionessuno.cadb.AdbState
 import kotlin.concurrent.atomics.AtomicInt
@@ -162,6 +163,12 @@ class ConfigurationViewModel private constructor(
         // (The order here informs the onboarding order)
         if (!notificationsEnabled) return AppState.NeedNotificationPermission
         if (!isConnectedToWifi) return AppState.NeedWifi
+        // Before enabling any debugging surface (bugbane is about to turn on
+        // wireless debugging), warn devices still exposed to the wireless-ADB
+        // bypass (CVE-2026-0073), once, until acknowledged.
+        if (DeviceVulnerabilityChecker.isAtRisk(appContext) && !appProgress.hasAckedAdbWarning) {
+            return AppState.NeedAdbVulnerabilityWarning
+        }
         if (!developerOptionsEnabled) return AppState.NeedDeveloperOptions
         if ((!wirelessDebuggingEnabled || needAdb) && !appProgress.hasCompletedOnboarding) return AppState.NeedWirelessDebuggingAndPair
 
@@ -212,6 +219,11 @@ class ConfigurationViewModel private constructor(
 
             AppState.NeedWelcomeScreen -> {
                 appManager.setHasSeenWelcomeScreen()
+            }
+
+            AppState.NeedAdbVulnerabilityWarning -> {
+                // The warning page renders in the slideshow; "Continue" acknowledges it.
+                appManager.setAckedAdbWarning()
             }
 
             AppState.NeedWifi,

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.osservatorionessuno.bugbane.MainActivity
+import org.osservatorionessuno.bugbane.security.AdbExposureNotifier
 import org.osservatorionessuno.bugbane.security.DeviceVulnerabilityChecker
 import org.osservatorionessuno.cadb.AdbManager
 import org.osservatorionessuno.cadb.AdbState
@@ -104,6 +105,16 @@ class ConfigurationViewModel private constructor(
                     // AdbPairingRequiredException, there's no point in autoconnecting til we fix it
                     autoConnectAttempts.store(_MAX_AUTOCONNECT_ATTEMPTS)
                 }
+
+                // Surface (or clear) the "wireless debugging is on and this device
+                // is unpatched" warning as the relevant state changes.
+                AdbExposureNotifier.update(
+                    appContext,
+                    vulnerable = DeviceVulnerabilityChecker.isAtRisk(appContext),
+                    wirelessDebuggingOn = settings.wirelessDebuggingEnabled,
+                    acquiring = adbState == AdbState.ConnectedAcquiring || adbState == AdbState.Cancelling,
+                    onboardingComplete = appProgress.hasCompletedOnboarding,
+                )
 
                 checkState(
                     settings.notificationsEnabled,

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/SlideshowManager.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/SlideshowManager.kt
@@ -11,14 +11,18 @@ import kotlinx.coroutines.flow.asStateFlow
 
 object SlideshowManager {
     private lateinit var appContext: Context
-    data class AppProgress(val hasCompletedOnboarding: Boolean, val hasSeenWelcomeScreen: Boolean)
-    private var _appProgress: MutableStateFlow<AppProgress> = MutableStateFlow(AppProgress(false, false))
+    data class AppProgress(
+        val hasCompletedOnboarding: Boolean,
+        val hasSeenWelcomeScreen: Boolean,
+        val hasAckedAdbWarning: Boolean,
+    )
+    private var _appProgress: MutableStateFlow<AppProgress> = MutableStateFlow(AppProgress(false, false, false))
     var appProgress: StateFlow<AppProgress> = _appProgress.asStateFlow()
     private lateinit var sharedPrefs: SharedPreferences
     private var sharedPrefsListener: SharedPreferences.OnSharedPreferenceChangeListener =
         SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
             when (key) {
-                Keys.KEY_HAS_SEEN_HOMEPAGE, Keys.KEY_HAS_SEEN_WELCOME_SCREEN -> {
+                Keys.KEY_HAS_SEEN_HOMEPAGE, Keys.KEY_HAS_SEEN_WELCOME_SCREEN, Keys.KEY_ACKED_ADB_WARNING -> {
                     checkState()
                 }
             }
@@ -49,12 +53,20 @@ object SlideshowManager {
             hasSeenWelcomeScreen = sharedPrefs.getBoolean(
                 Keys.KEY_HAS_SEEN_WELCOME_SCREEN,
                 false
+            ),
+            hasAckedAdbWarning = sharedPrefs.getBoolean(
+                Keys.KEY_ACKED_ADB_WARNING,
+                false
             )
         )
         if (_appProgress.value != newState) {
             Log.d("SlideshowManager", "update appprogress (onboardcomplete=${newState.hasCompletedOnboarding}, welcomecomplete=${newState.hasSeenWelcomeScreen})")
             _appProgress.value = newState
         }
+    }
+
+    fun setAckedAdbWarning() {
+        sharedPrefs.edit { putBoolean(Keys.KEY_ACKED_ADB_WARNING, true) }
     }
 
     fun hasSeenHomepage(): Boolean {
@@ -97,4 +109,7 @@ object Keys {
 
     // Skips the beta warning countdown after the user has acknowledged it once
     const val KEY_BETA_WARNING_ACKNOWLEDGED = "beta_warning_acknowledged"
+
+    // Set once the user has acknowledged the ADB vulnerability warning
+    const val KEY_ACKED_ADB_WARNING = "acked_adb_warning"
 }

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,6 +19,11 @@
     <string name="slideshow_developer_title">Abilita opzioni sviluppatore</string>
     <string name="slideshow_developer_description">Per utilizzare quesa applicazione, è necessario abilitare le opzioni sviluppatore.\n\nL\'applicazione acquisisce dati usando l\'ADB Wireless Debugging, che è disponibile solo quando le opzioni sviluppatore sono abilitate.</string>
     <string name="slideshow_button_text_enable">Abilita</string>
+    <string name="adb_vuln_title">Il tuo dispositivo deve essere aggiornato</string>
+    <string name="adb_vuln_description">A questo telefono manca una correzione di sicurezza di Android (CVE-2026-0073). Durante una scansione di Bugbane, altre persone sulla stessa rete Wi-Fi potrebbero usare questa falla per accedere al telefono. Installa prima gli aggiornamenti di sistema.</string>
+    <string name="adb_vuln_network_warning">Non puoi aggiornare adesso? Esegui la scansione solo connesso a un hotspot personale creato da un altro telefono o computer di cui ti fidi — mai su Wi-Fi pubbliche o condivise. Disattiva il Wireless Debugging subito dopo.</string>
+    <string name="adb_vuln_update_button">Controlla aggiornamenti</string>
+    <string name="adb_vuln_continue_button">Ho capito, continua comunque</string>
     <string name="slideshow_wireless_and_pair_title">Abilita Wireless Debugging e accoppia</string>
     <string name="slideshow_wireless_and_pair_description">Connettiti ad una rete Wi-Fi, abilita l\'opzione ADB Wireless Debugging, premi \"Accoppia dispositivo con codice di accoppiamento\", poi inserirsci il codice visualizzato nella notifica di Bugbane.</string>
     <string name="slideshow_wireless_and_pair_button">Accoppia</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,9 +36,14 @@
     <!-- ADB wireless-debugging vulnerability warning (CVE-2026-0073) -->
     <string name="adb_vuln_title">Your device needs an update</string>
     <string name="adb_vuln_description">This device is missing a security update for a serious flaw in Android\'s wireless debugging (CVE-2026-0073). Because Bugbane works by turning on wireless debugging, on an unpatched device an attacker on the same network could gain access without any action from you. Please install system updates before continuing.</string>
-    <string name="adb_vuln_network_warning">If you continue without updating, you MUST do so only on a network you fully trust — ideally your own personal hotspot — and never on public or shared Wi-Fi.</string>
+    <string name="adb_vuln_network_warning">If you continue without updating, you MUST do so only on a network you fully trust — your own personal hotspot or an ad-hoc network — and never on public or shared Wi-Fi. Turn Wireless Debugging back off immediately after each acquisition.</string>
     <string name="adb_vuln_update_button">Check for updates</string>
     <string name="adb_vuln_continue_button">I understand, continue anyway</string>
+
+    <!-- Ongoing notification: wireless debugging is on and the device is unpatched -->
+    <string name="notification_channel_adb_exposure">Wireless debugging exposure</string>
+    <string name="adb_exposure_notification_title">Turn off Wireless Debugging</string>
+    <string name="adb_exposure_notification_text">This device is missing the CVE-2026-0073 fix and Wireless Debugging is on, so it can be attacked over the network. Turn it off until your next acquisition — tap to open Developer Options.</string>
 
     <string name="slideshow_wireless_and_pair_title">Enable Wireless Debugging and Pair</string>
     <string name="slideshow_wireless_and_pair_description">Connect to Wi-Fi, enable ADB Wireless Debugging, tap “Pair device with pairing code,” then enter the code in the Bugbane notification.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,13 @@
     The application acquires data using ADB Wireless Debugging, which is available only when Developer Options are enabled.</string>
     <string name="slideshow_button_text_enable">Enable</string>
 
+    <!-- ADB wireless-debugging vulnerability warning (CVE-2026-0073) -->
+    <string name="adb_vuln_title">Your device needs an update</string>
+    <string name="adb_vuln_description">This device is missing a security update for a serious flaw in Android\'s wireless debugging (CVE-2026-0073). Because Bugbane works by turning on wireless debugging, on an unpatched device an attacker on the same network could gain access without any action from you. Please install system updates before continuing.</string>
+    <string name="adb_vuln_network_warning">If you continue without updating, you MUST do so only on a network you fully trust — ideally your own personal hotspot — and never on public or shared Wi-Fi.</string>
+    <string name="adb_vuln_update_button">Check for updates</string>
+    <string name="adb_vuln_continue_button">I understand, continue anyway</string>
+
     <string name="slideshow_wireless_and_pair_title">Enable Wireless Debugging and Pair</string>
     <string name="slideshow_wireless_and_pair_description">Connect to Wi-Fi, enable ADB Wireless Debugging, tap “Pair device with pairing code,” then enter the code in the Bugbane notification.</string>
     <string name="slideshow_wireless_and_pair_button">Pair</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,8 +35,8 @@
 
     <!-- ADB wireless-debugging vulnerability warning (CVE-2026-0073) -->
     <string name="adb_vuln_title">Your device needs an update</string>
-    <string name="adb_vuln_description">This device is missing a security update for a serious flaw in Android\'s wireless debugging (CVE-2026-0073). Because Bugbane works by turning on wireless debugging, on an unpatched device an attacker on the same network could gain access without any action from you. Please install system updates before continuing.</string>
-    <string name="adb_vuln_network_warning">If you continue without updating, you MUST do so only on a network you fully trust — your own personal hotspot or an ad-hoc network — and never on public or shared Wi-Fi. Turn Wireless Debugging back off immediately after each acquisition.</string>
+    <string name="adb_vuln_description">This phone is missing an Android security fix (CVE-2026-0073). While Bugbane scans, other people on the same Wi-Fi network could use that flaw to access the phone. Install system updates first.</string>
+    <string name="adb_vuln_network_warning">Can\'t update now? Scan only while connected to a personal hotspot made by another phone or computer you trust — never on shared or public Wi-Fi. Turn Wireless Debugging off right after.</string>
     <string name="adb_vuln_update_button">Check for updates</string>
     <string name="adb_vuln_continue_button">I understand, continue anyway</string>
 

--- a/app/src/test/java/org/osservatorionessuno/bugbane/security/DeviceVulnerabilityCheckerTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/security/DeviceVulnerabilityCheckerTest.kt
@@ -1,0 +1,58 @@
+package org.osservatorionessuno.bugbane.security
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeviceVulnerabilityCheckerTest {
+
+    private val adv = VulnerabilityAdvisory(
+        id = "CVE-2026-0073",
+        infoUrl = "https://example.test",
+        minAffectedSdk = 34,
+        maxAffectedSdk = 36,
+        fixedSecurityPatch = "2026-05-01",
+        fixedTrain = "2026-05",
+    )
+
+    private fun evaluate(sdk: Int, patch: String?, train: String?) =
+        DeviceVulnerabilityChecker.evaluate(sdk, patch, train, adv)
+
+    @Test
+    fun `older Android is not affected`() {
+        assertEquals(VulnerabilityStatus.NOT_APPLICABLE, evaluate(33, "2025-01-01", "2025-01"))
+    }
+
+    @Test
+    fun `newer Android is out of the affected range`() {
+        assertEquals(VulnerabilityStatus.NOT_APPLICABLE, evaluate(37, "2026-01-01", "2026-01"))
+    }
+
+    @Test
+    fun `patched security level clears regardless of train`() {
+        assertEquals(VulnerabilityStatus.PROTECTED, evaluate(34, "2026-05-01", "2026-01"))
+        assertEquals(VulnerabilityStatus.PROTECTED, evaluate(36, "2026-06-01", null))
+    }
+
+    @Test
+    fun `mainline train at or after the fix clears an unpatched platform`() {
+        assertEquals(VulnerabilityStatus.PROTECTED, evaluate(34, "2026-04-01", "2026-05"))
+        assertEquals(VulnerabilityStatus.PROTECTED, evaluate(34, "2026-01-01", "2026-07"))
+    }
+
+    @Test
+    fun `both channels old is confirmed at risk`() {
+        assertEquals(VulnerabilityStatus.AT_RISK, evaluate(34, "2026-04-30", "2026-04"))
+        assertEquals(VulnerabilityStatus.AT_RISK, evaluate(36, "2026-03-01", "2026-03"))
+    }
+
+    @Test
+    fun `old patch with unreadable train is undetermined, never a false clear`() {
+        assertEquals(VulnerabilityStatus.UNDETERMINED, evaluate(34, "2026-04-01", null))
+        assertEquals(VulnerabilityStatus.UNDETERMINED, evaluate(34, null, null))
+    }
+
+    @Test
+    fun `patch one day before the fix does not clear on its own`() {
+        assertEquals(VulnerabilityStatus.AT_RISK, evaluate(34, "2026-04-30", "2026-04"))
+    }
+}


### PR DESCRIPTION
Given CVE-2026-0073 this patch does the following checks:
 - Checks if the API level is one of the potentially affected ones
 - Checks the Security Patch Level
 - Checks the specific system update version

There's multiple ways for user to not be affected:
 - Being on an unaffected API version
 - Having performed a recent enough system upate
 - Automatic system patching via GMS
 
This adds a page in the slideshow, before enabling developer options that performs the checks. If an least on indicator tells us the device is unaffected or patched, we skip. If we have a good suspicion of the vulnerability being present, we redirect the user to the system updates page of Play Services when available. User are allowed to proceed, with a strong warning that they should do so only on personal hotspots and ad-hoc networks and that they should immediately disable Wireless ADB after an acquisition. 