### PR TITLE
Support chunked OHTTP, memory safe updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,9 +154,6 @@ dependencies {
     // Streaming encrypted+compressed acquisition archive (age + ZIP) engine.
     implementation(project(":crypto"))
 
-    // Applying the update feed's unified-diff deltas
-    implementation(libs.java.diff.utils)
-
     // Tombstone protobuf (lite)
     implementation(libs.protobuf.javalite)
 

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/BundledIndicators.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/BundledIndicators.kt
@@ -7,10 +7,9 @@ import android.util.Log
  * Seeds [IndicatorStore] from the IOC set bundled in the APK, so the app analyzes offline out of
  * the box.
  *
- * The snapshot is committed under `assets/[ASSET_DIR]/` (`update.json` + `indicators.json`,
- * refreshed by the `refreshBundledIndicators` Gradle task). Adopted when newer than the stored
- * set (fresh install, or an app update newer than the last online fetch); [IndicatorUpdater]
- * handles online updates.
+ * The snapshot is committed under `assets/[ASSET_DIR]/` (`update.json` + `indicators.json`).
+ * Adopted when newer than the stored set (fresh install, or an app update newer than the last
+ * online fetch); [IndicatorUpdater] handles online updates.
  *
  * Cheap when unchanged (metadata read + version compare); the bundle is read only when adopted.
  */
@@ -36,12 +35,17 @@ object BundledIndicators {
         // Keep the stored set if it is the same schema and at least as new.
         if (local.schema == meta.schema && local.version >= meta.version) return
 
-        val bundle = runCatching { assets.open(BUNDLE_ASSET).use { it.readBytes() } }.getOrNull() ?: run {
-            Log.w(TAG, "Bundled indicators.json missing though update.json present; skipping seed")
+        // Adopt through the shared gate, streaming the asset straight into the staging file — the
+        // bundle is never held in memory. Timestamps are 0: this set was never fetched online, so
+        // the updater still runs and the UI reads "not yet checked online".
+        val objectCount = try {
+            IndicatorAdoption.adopt(store, meta, checkedAtEpoch = 0, updatedAtEpoch = 0) { out ->
+                assets.open(BUNDLE_ASSET).use { it.copyTo(out) }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Bundled indicators.json missing or unreadable though update.json present; skipping seed", e)
             return
         }
-        // Adopt via the shared gate with timestamps 0 (this set was never fetched online).
-        val objectCount = IndicatorAdoption.adopt(store, meta, bundle, checkedAtEpoch = 0, updatedAtEpoch = 0)
         if (objectCount == null) {
             Log.w(TAG, "Bundled indicators failed verification (hash mismatch); skipping seed")
             return

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/DeltaPatch.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/DeltaPatch.kt
@@ -1,25 +1,138 @@
 package org.osservatorionessuno.bugbane.update
 
-import com.github.difflib.UnifiedDiffUtils
-import com.github.difflib.patch.PatchFailedException
+import java.io.IOException
+import java.io.OutputStream
+import java.io.Reader
 
 /**
  * Applies the update feed's deltas (zero-context unified diffs produced by the bugbane-updater
- * builder) using java-diff-utils. The result is only adopted if its SHA-256 equals the signed full
- * hash, so the caller treats any failure here as a reason to fall back to a full download.
+ * builder) in a single streaming pass: the local bundle is read line by line from a [Reader] and
+ * the reconstructed full is written straight to an [OutputStream], so peak memory is bounded by
+ * the delta size, never the bundle size.
  *
+ * The caller only adopts the result if its SHA-256 equals the signed full hash, so any mismatch or
+ * [IOException] here just means falling back to a full download.
+ *
+ * Line semantics match the builder's: the bundle is a sequence of `\n`-separated segments (a file
+ * with a trailing newline ends in an empty segment), and hunk line numbers are 1-based indices
+ * into that sequence. Output is the segments joined by `\n`, which reproduces the input bytes
+ * exactly where hunks don't touch them.
  */
 object DeltaPatch {
 
-    /** @throws PatchFailedException if the diff's removed lines don't match [full] (e.g. corruption). */
-    fun apply(full: ByteArray, delta: ByteArray): ByteArray {
-        val source = String(full, Charsets.UTF_8).split("\n")
+    /** @throws IOException if the diff is malformed or its removed lines don't match [source]. */
+    fun apply(source: Reader, delta: ByteArray, out: OutputStream) {
         val deltaLines = String(delta, Charsets.UTF_8).split("\n").toMutableList()
         // Drop the trailing empty element from the delta's own trailing newline before parsing.
         if (deltaLines.isNotEmpty() && deltaLines.last().isEmpty()) deltaLines.removeAt(deltaLines.size - 1)
 
-        val patch = UnifiedDiffUtils.parseUnifiedDiff(deltaLines)
-        val out = patch.applyTo(source)
-        return out.joinToString("\n").toByteArray(Charsets.UTF_8)
+        val src = LineSource(source)
+        val sink = LineSink(out)
+
+        var i = 0
+        while (i < deltaLines.size) {
+            val header = deltaLines[i]
+            // Anything outside a hunk body that isn't a hunk header (`---`/`+++` file headers) is skipped.
+            if (!header.startsWith("@@")) {
+                i++
+                continue
+            }
+            val hunk = parseHunkHeader(header)
+            i++
+
+            // Copy the untouched lines between the previous hunk and this one. A zero-length
+            // removal means "insert after line N", so the insertion point itself is copied too.
+            val firstTouched = if (hunk.removeCount == 0) hunk.removeStart else hunk.removeStart - 1
+            if (firstTouched < src.consumed) throw IOException("Delta hunks overlap or are out of order")
+            while (src.consumed < firstTouched) {
+                sink.write(src.next() ?: throw IOException("Delta hunk starts beyond end of bundle"))
+            }
+
+            var removeLeft = hunk.removeCount
+            var addLeft = hunk.addCount
+            while (removeLeft > 0 || addLeft > 0) {
+                if (i >= deltaLines.size) throw IOException("Delta hunk truncated")
+                val body = deltaLines[i]
+                i++
+                when {
+                    body.startsWith("-") -> {
+                        if (removeLeft <= 0) throw IOException("Delta hunk removes more lines than declared")
+                        val actual = src.next() ?: throw IOException("Delta removes beyond end of bundle")
+                        if (actual != body.substring(1)) {
+                            throw IOException("Delta does not match local bundle at line ${src.consumed}")
+                        }
+                        removeLeft--
+                    }
+                    body.startsWith("+") -> {
+                        if (addLeft <= 0) throw IOException("Delta hunk adds more lines than declared")
+                        sink.write(body.substring(1))
+                        addLeft--
+                    }
+                    body.startsWith(" ") -> {
+                        // The builder emits zero-context diffs; tolerate context lines anyway.
+                        if (removeLeft <= 0 || addLeft <= 0) throw IOException("Unexpected context line in delta hunk")
+                        val actual = src.next() ?: throw IOException("Delta context beyond end of bundle")
+                        if (actual != body.substring(1)) {
+                            throw IOException("Delta context does not match local bundle at line ${src.consumed}")
+                        }
+                        sink.write(actual)
+                        removeLeft--
+                        addLeft--
+                    }
+                    body.startsWith("\\") -> Unit // "\ No newline at end of file" marker
+                    else -> throw IOException("Malformed delta hunk line")
+                }
+            }
+        }
+
+        // Copy the tail of the bundle untouched.
+        while (true) sink.write(src.next() ?: break)
+    }
+
+    private class Hunk(val removeStart: Int, val removeCount: Int, val addCount: Int)
+
+    private val HUNK_HEADER = Regex("""^@@ -(\d+)(?:,(\d+))? \+\d+(?:,(\d+))? @@""")
+
+    private fun parseHunkHeader(line: String): Hunk {
+        val m = HUNK_HEADER.find(line) ?: throw IOException("Malformed delta hunk header: $line")
+        return Hunk(
+            removeStart = m.groupValues[1].toInt(),
+            removeCount = m.groupValues[2].ifEmpty { "1" }.toInt(),
+            addCount = m.groupValues[3].ifEmpty { "1" }.toInt(),
+        )
+    }
+
+    /** Yields the `\n`-separated segments of [reader]; [consumed] counts segments read so far. */
+    private class LineSource(private val reader: Reader) {
+        var consumed = 0
+            private set
+        private var eof = false
+
+        fun next(): String? {
+            if (eof) return null
+            val sb = StringBuilder()
+            while (true) {
+                val c = reader.read()
+                if (c == -1) {
+                    eof = true
+                    break
+                }
+                if (c == '\n'.code) break
+                sb.append(c.toChar())
+            }
+            consumed++
+            return sb.toString()
+        }
+    }
+
+    /** Writes segments joined by `\n` (a separator before every segment except the first). */
+    private class LineSink(private val out: OutputStream) {
+        private var first = true
+
+        fun write(line: String) {
+            if (!first) out.write('\n'.code)
+            out.write(line.toByteArray(Charsets.UTF_8))
+            first = false
+        }
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorAdoption.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorAdoption.kt
@@ -1,27 +1,27 @@
 package org.osservatorionessuno.bugbane.update
 
+import java.io.OutputStream
+
 /**
  * The single point where a candidate indicator set is verified and written to the store.
  *
  * Every source converges here — the online [IndicatorUpdater], the APK-bundled set
  * ([BundledIndicators]), and (future) a set loaded from disk — so nothing reaches the store
- * without passing [verify], and the store is only ever written in one place.
+ * without passing verification, and the store is only ever written in one place.
  *
- * Signature / sigsum verification is intentionally NOT done yet; when it is added it goes in
- * [verify], which is enough to cover every source at once.
+ * Signature / sigsum verification is intentionally NOT done yet; when it is added it goes next to
+ * the hash check in [adopt], which is enough to cover every source at once.
  */
 object IndicatorAdoption {
 
     /**
-     * Whether [bundle] is exactly the set [meta] describes. Integrity only, for now — the feed
-     * signature / sigsum proof over [meta] will also be checked here later.
-     */
-    fun verify(meta: UpdateMetadata, bundle: ByteArray): Boolean =
-        OhttpTransport.sha256Hex(bundle) == meta.sha256
-
-    /**
-     * [verify] [bundle] against [meta] and, on success, atomically replace the stored set with it.
-     * Returns the adopted object count, or null if verification failed (nothing is written).
+     * Stream a candidate set from [writeTo], verify it is exactly the set [meta] describes, and on
+     * success atomically replace the stored set with it. The candidate goes through a scratch file
+     * (never memory), and adoption — the rename plus state write — only happens after the SHA-256
+     * computed over the exact staged bytes matches `meta.sha256`.
+     *
+     * Returns the adopted object count, or null if verification failed (the scratch file is
+     * discarded and nothing is adopted).
      *
      * [checkedAtEpoch] / [updatedAtEpoch] record when this adoption happened; pass 0 for a source
      * that isn't an online check (e.g. the bundled set), so the UI still reads "not checked online".
@@ -29,25 +29,30 @@ object IndicatorAdoption {
     fun adopt(
         store: IndicatorStore,
         meta: UpdateMetadata,
-        bundle: ByteArray,
         checkedAtEpoch: Long,
         updatedAtEpoch: Long,
+        writeTo: (OutputStream) -> Unit,
     ): Int? {
-        if (!verify(meta, bundle)) return null
-        val objectCount = store.writeBundle(bundle)
+        val staged = store.stage(writeTo)
+        if (staged.sha256 != meta.sha256) {
+            staged.discard()
+            return null
+        }
+        store.adoptStaged(staged)
         store.writeState(
             IndicatorStore.State(
                 schema = meta.schema,
                 version = meta.version,
-                // verify() passed, so this equals the hash of the bytes just written.
-                sha256 = meta.sha256,
+                // Computed over the staged bytes, so `state.sha256 == hash(bundle on disk)`
+                // holds by construction (and it equals meta.sha256, or we wouldn't be here).
+                sha256 = staged.sha256,
                 sunset = meta.sunset,
                 buildDate = meta.buildDate,
-                objectCount = objectCount,
+                objectCount = staged.objectCount,
                 lastCheckEpoch = checkedAtEpoch,
                 lastUpdateEpoch = updatedAtEpoch,
             ),
         )
-        return objectCount
+        return staged.objectCount
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorStore.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorStore.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.util.Log
 import org.json.JSONObject
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.MessageDigest
 
 /**
  * Bugbane-owned on-disk state for the indicator feed, replacing libmvt's `IndicatorsUpdates` for
@@ -67,32 +70,61 @@ class IndicatorStore(private val filesDir: File) {
         atomicWrite(stateFile, o.toString().toByteArray(Charsets.UTF_8))
     }
 
-    /** The locally adopted full bundle, or null if none has been written. */
-    fun readBundle(): ByteArray? = if (bundleFile.exists()) bundleFile.readBytes() else null
+    /** Whether a full bundle has been adopted. */
+    fun hasBundle(): Boolean = bundleFile.exists()
 
-    /** Atomically replace the indicators directory contents with a single full STIX bundle. */
+    /** The locally adopted full bundle as a stream, or null if none has been written. */
+    fun openBundle(): InputStream? = if (bundleFile.exists()) bundleFile.inputStream() else null
 
-    fun writeBundle(bytes: ByteArray): Int {
+    /**
+     * A candidate bundle streamed to a scratch file, with its SHA-256 and object count computed
+     * while writing — the bundle itself is never held in memory. Either [adoptStaged] or
+     * [discard][Staged.discard] it.
+     */
+    class Staged internal constructor(internal val file: File, val sha256: String, val objectCount: Int) {
+        fun discard() {
+            file.delete()
+        }
+    }
+
+    /** Stream a candidate bundle from [writeTo] into a scratch file next to the real one. */
+    fun stage(writeTo: (OutputStream) -> Unit): Staged {
+        val tmp = File(indicatorsDir, bundleFile.name + ".tmp")
+        val digest = MessageDigest.getInstance("SHA-256")
+        var newlines = 0
+        try {
+            tmp.outputStream().buffered().use { fileOut ->
+                writeTo(object : OutputStream() {
+                    override fun write(b: Int) {
+                        digest.update(b.toByte())
+                        if (b.toByte() == NL) newlines++
+                        fileOut.write(b)
+                    }
+
+                    override fun write(b: ByteArray, off: Int, len: Int) {
+                        digest.update(b, off, len)
+                        for (i in off until off + len) if (b[i] == NL) newlines++
+                        fileOut.write(b, off, len)
+                    }
+                })
+            }
+        } catch (e: Throwable) {
+            tmp.delete()
+            throw e
+        }
+        val sha256 = digest.digest().joinToString("") { "%02x".format(it) }
+        return Staged(tmp, sha256, objectCount(newlines))
+    }
+
+    /** Atomically replace the stored bundle with [staged], clearing any stale indicator files. */
+    fun adoptStaged(staged: Staged) {
         indicatorsDir.listFiles()?.forEach { f ->
             if (f != bundleFile && (f.name.endsWith(".json") || f.name.endsWith(".stix2"))) f.delete()
         }
-        val tmp = File(indicatorsDir, bundleFile.name + ".tmp")
-        var newlines = 0
-        tmp.outputStream().use { out ->
-            var i = 0
-            while (i < bytes.size) {
-                val end = minOf(i + COPY_CHUNK, bytes.size)
-                for (j in i until end) if (bytes[j] == NL) newlines++
-                out.write(bytes, i, end - i)
-                i = end
-            }
-        }
-        rename(tmp, bundleFile)
-        return objectCount(newlines)
+        rename(staged.file, bundleFile)
     }
 
-    fun countObjects(bytes: ByteArray): Int = objectCount(bytes.count { it == NL })
-
+    /** Builder framing is head line + one object per line + tail line, hence newlines - 2. */
     private fun objectCount(newlines: Int): Int = (newlines - 2).coerceAtLeast(0)
 
     private fun atomicWrite(target: File, bytes: ByteArray) {
@@ -113,7 +145,6 @@ class IndicatorStore(private val filesDir: File) {
         private const val STATE_FILE = "indicator_update_state.json"
         private const val INDICATORS_DIR = "bugbane-indicators"
         private const val BUNDLE_FILE = "indicators.json"
-        private const val COPY_CHUNK = 64 * 1024
         private val NL = '\n'.code.toByte()
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorUpdater.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/IndicatorUpdater.kt
@@ -67,23 +67,20 @@ class IndicatorUpdater(
         }
 
         val gap = meta.version - local.version
-        val localFull = store.readBundle()
-        val canDelta = local.version > 0 && local.schema == SCHEMA && gap in 1..DELTA_WINDOW && localFull != null
+        val canDelta = local.version > 0 && local.schema == SCHEMA && gap in 1..DELTA_WINDOW && store.hasBundle()
 
+        // Both paths adopt through the single gate (see IndicatorAdoption): the candidate streams
+        // to a scratch file and is only adopted if the hash computed on the way through verifies.
         var viaDelta = false
-        var verified: Verified? = null
+        var objectCount: Int? = null
         if (canDelta) {
-            verified = tryDelta(localFull!!, local.version, meta)
-            viaDelta = verified != null
+            objectCount = tryDelta(local.version, meta, checkedAt)
+            viaDelta = objectCount != null
         }
-        if (verified == null) {
-            verified = fetchFull(meta) ?: return Outcome.Failed("full download failed", sunset)
+        if (objectCount == null) {
+            objectCount = fetchFull(meta, checkedAt)
+                ?: return Outcome.Failed("full download or verification failed", sunset)
         }
-
-        // Adopt through the single gate (see IndicatorAdoption): it re-verifies before touching
-        // disk, so `state.sha256 == hash(bundle on disk)` holds and every source converges here.
-        val objectCount = IndicatorAdoption.adopt(store, meta, verified.bytes, checkedAt, checkedAt)
-            ?: return Outcome.Failed("bundle failed verification", sunset)
         Log.i(TAG, "Adopted version ${meta.version} (${if (viaDelta) "delta" else "full"}), $objectCount objects")
         return Outcome.Updated(
             fromVersion = local.version,
@@ -94,51 +91,47 @@ class IndicatorUpdater(
         )
     }
 
-    /** Fetch and apply `delta-<local>-<target>.diff`; returns the reconstructed full iff the hash we
-     *  compute over it matches the feed's advertised hash. */
-    private fun tryDelta(localFull: ByteArray, localVersion: Int, meta: UpdateMetadata): Verified? {
+    /** Fetch `delta-<local>-<target>.diff` and stream-patch the on-disk bundle through the adoption
+     *  gate; returns the adopted object count iff the reconstructed full verifies. */
+    private fun tryDelta(localVersion: Int, meta: UpdateMetadata, checkedAt: Long): Int? {
         return try {
             val resp = transport.get("$BASE/deltas/delta-$localVersion-${meta.version}.diff")
             if (resp.statusCode != 200) {
                 Log.i(TAG, "Delta delta-$localVersion-${meta.version} not available (status ${resp.statusCode}); using full")
                 return null
             }
-            val candidate = DeltaPatch.apply(localFull, resp.body)
-            val hash = OhttpTransport.sha256Hex(candidate)
-            if (hash == meta.sha256) {
-                Verified(candidate)
-            } else {
-                Log.w(TAG, "Delta result hash mismatch; falling back to full")
-                null
+            val adopted = IndicatorAdoption.adopt(store, meta, checkedAt, checkedAt) { out ->
+                store.openBundle()!!.bufferedReader(Charsets.UTF_8).use { local ->
+                    DeltaPatch.apply(local, resp.body, out)
+                }
             }
+            if (adopted == null) Log.w(TAG, "Delta result hash mismatch; falling back to full")
+            adopted
         } catch (e: Exception) {
             Log.w(TAG, "Delta apply failed; falling back to full", e)
             null
         }
     }
 
-    /** Download the content-addressed full bundle and return it iff the hash we compute matches. */
-    private fun fetchFull(meta: UpdateMetadata): Verified? {
+    /** Download the content-addressed full bundle, streaming it straight through the adoption
+     *  gate — it is never held in memory — and adopt it iff the hash we compute matches. */
+    private fun fetchFull(meta: UpdateMetadata, checkedAt: Long): Int? {
         return try {
-            val resp = transport.get("$BASE/${meta.sha256}.json")
-            if (resp.statusCode != 200) {
-                Log.e(TAG, "Full ${meta.sha256}.json -> inner status ${resp.statusCode}")
-                return null
+            transport.getStream("$BASE/${meta.sha256}.json") { status, body ->
+                if (status != 200) {
+                    Log.e(TAG, "Full ${meta.sha256}.json -> inner status $status")
+                    null
+                } else {
+                    val adopted = IndicatorAdoption.adopt(store, meta, checkedAt, checkedAt) { body.copyTo(it) }
+                    if (adopted == null) Log.e(TAG, "Full bundle hash mismatch (expected ${meta.sha256})")
+                    adopted
+                }
             }
-            val hash = OhttpTransport.sha256Hex(resp.body)
-            if (hash != meta.sha256) {
-                Log.e(TAG, "Full bundle hash mismatch (expected ${meta.sha256}, got $hash)")
-                return null
-            }
-            Verified(resp.body)
         } catch (e: Exception) {
             Log.e(TAG, "Full download failed", e)
             null
         }
     }
-
-    /** A bundle whose SHA-256 we computed ourselves and confirmed equals the feed's advertised hash. */
-    private class Verified(val bytes: ByteArray)
 
     companion object {
         private const val TAG = "IndicatorUpdater"

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
@@ -14,7 +14,6 @@ import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.security.MessageDigest
 import java.util.Base64
 import java.util.zip.GZIPInputStream
 
@@ -170,9 +169,5 @@ class OhttpTransport : UpdateTransport {
 
         /** Hard ceiling on a gzip-decompressed response body (128MB). */
         private const val MAX_DECOMPRESSED_BYTES = 128L * 1024 * 1024
-
-        fun sha256Hex(bytes: ByteArray): String =
-            MessageDigest.getInstance("SHA-256").digest(bytes)
-                .joinToString("") { "%02x".format(it) }
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
@@ -3,13 +3,13 @@ package org.osservatorionessuno.bugbane.update
 import android.util.Log
 import org.osservatorionessuno.libbhttp.BhttpRequest
 import org.osservatorionessuno.libbhttp.BhttpResponse
-import org.osservatorionessuno.libbhttp.decodeResponse
+import org.osservatorionessuno.libbhttp.decodeResponseStream
 import org.osservatorionessuno.libbhttp.encodeRequest
-import org.osservatorionessuno.libohttp.MEDIA_TYPE_REQUEST
-import org.osservatorionessuno.libohttp.MEDIA_TYPE_RESPONSE
+import org.osservatorionessuno.libohttp.MEDIA_TYPE_CHUNKED_REQUEST
+import org.osservatorionessuno.libohttp.MEDIA_TYPE_CHUNKED_RESPONSE
 import org.osservatorionessuno.libohttp.OhttpClient
 import org.osservatorionessuno.libohttp.bouncycastle.BouncyCastleHpkeBackend
-import java.io.ByteArrayOutputStream
+import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -18,22 +18,32 @@ import java.security.MessageDigest
 import java.util.Base64
 
 /**
- * Oblivious HTTP (RFC 9458) transport for the indicator update feed.
+ * Oblivious HTTP transport for the indicator update feed, using the chunked variant
+ * (draft-ietf-ohai-chunked-ohttp) for every request: response chunks are decrypted and released
+ * as they arrive — each only after its own AEAD tag verified — so even the full bundle is never
+ * held in memory. Chunked-ness is part of the gateway configuration the client knows, and per the
+ * draft's consistency considerations (§7) there is no fallback to the non-chunked variant.
  *
- * Every update request is encoded as BHTTP, encapsulated against the gateway's key config, and
- * POSTed through an Oblivious relay so the gateway never sees the client address.
- *
- * The key config is shipped with the app ([EMBEDDED_KEY_CONFIG]).
+ * Every request is encoded as BHTTP, encapsulated against the gateway's key config, and POSTed
+ * through an Oblivious relay so the gateway never sees the client address. The key config is
+ * shipped with the app ([EMBEDDED_KEY_CONFIG]).
  */
 class OhttpTransport : UpdateTransport {
     private val client: OhttpClient = OhttpClient.fromKeyConfigList(EMBEDDED_KEY_CONFIG, BouncyCastleHpkeBackend())
 
+    override fun get(path: String): BhttpResponse = getStream(path) { status, body -> BhttpResponse(status, emptyList(), body.readBytes()) }
+
     /**
-     * Issue an oblivious GET for [path] (an absolute path on the update origin, e.g. `/v1/update.json`)
-     * and return the decoded inner BHTTP response.
+     * Issue an oblivious GET for [path] (an absolute path on the update origin, e.g.
+     * `/v1/update.json`) and hand the inner status and body to [consume] while the response
+     * streams from the wire.
      */
-    override fun get(path: String): BhttpResponse {
-        val bhttp = encodeRequest(
+    override fun <T> getStream(
+        path: String,
+        consume: (Int, InputStream) -> T,
+    ): T {
+        val request = client.encapsulateChunkedRequest()
+        val inner = encodeRequest(
             BhttpRequest(
                 method = "GET",
                 scheme = TARGET_SCHEME,
@@ -42,23 +52,16 @@ class OhttpTransport : UpdateTransport {
                 headers = listOf("accept" to "*/*"),
             ),
         )
-        val encapsulated = client.encapsulateRequest(bhttp)
-        val ohttpResponse = relayPost(encapsulated.bytes)
-        val responseBytes = encapsulated.decapsulateResponse(ohttpResponse)
-        val response = decodeResponse(responseBytes)
-        Log.i(TAG, "GET $path -> inner status ${response.statusCode}, ${response.body.size} bytes")
-        return response
-    }
+        val body = request.header + request.sealFinalChunk(inner)
 
-    /** POST the encapsulated request to the relay (the only host the client talks to) and return the
-     * raw `message/ohttp-res` bytes. */
-    private fun relayPost(body: ByteArray): ByteArray {
         val conn = (URL(RELAY_URL).openConnection() as HttpURLConnection).apply {
             requestMethod = "POST"
             connectTimeout = TIMEOUT_MS
             readTimeout = TIMEOUT_MS
-            setRequestProperty("Accept", MEDIA_TYPE_RESPONSE)
-            setRequestProperty("Content-Type", MEDIA_TYPE_REQUEST)
+            setRequestProperty("Accept", MEDIA_TYPE_CHUNKED_RESPONSE)
+            setRequestProperty("Content-Type", MEDIA_TYPE_CHUNKED_REQUEST)
+            // Ask intermediaries (the relay) to forward the body progressively instead of buffering
+            setRequestProperty("Incremental", "?1")
             doOutput = true
             setFixedLengthStreamingMode(body.size)
         }
@@ -66,32 +69,60 @@ class OhttpTransport : UpdateTransport {
             conn.outputStream.use { it.write(body) }
             val code = conn.responseCode
             if (code !in 200..299) {
-                val err = conn.errorStream?.use { it.readBytes() } ?: ByteArray(0)
-                throw IOException("POST $RELAY_URL -> HTTP $code (${err.size} bytes of error body)")
+                // Only the size is reported, so drain counting bytes — buffering would hand the
+                // untrusted relay an unbounded allocation on the error path.
+                val errSize = conn.errorStream?.use { drainCounting(it) } ?: 0L
+                throw IOException("POST $RELAY_URL -> HTTP $code ($errSize bytes of error body)")
             }
-            return conn.inputStream.use { readBounded(it) }
+            if (conn.contentType?.contains(MEDIA_TYPE_CHUNKED_RESPONSE) != true) {
+                throw IOException("unexpected relay content type ${conn.contentType}")
+            }
+            conn.inputStream.use { raw ->
+                val plaintext = request.decapsulateChunkedResponse(BoundedInputStream(raw))
+                val response = decodeResponseStream(plaintext)
+                Log.i(TAG, "GET $path -> inner status ${response.statusCode}")
+                return consume(response.statusCode, response.body)
+            }
         } finally {
             conn.disconnect()
         }
     }
 
-    /**
-     * Read the relay response with a hard ceiling. The relay is a separate, not-fully-trusted party,
-     * so an unbounded read would let a rogue relay OOM the app; [MAX_RESPONSE_BYTES] bounds it while
-     * leaving generous headroom over the real bundle size.
-     */
-    private fun readBounded(input: InputStream): ByteArray {
-        val buffer = ByteArrayOutputStream()
-        val chunk = ByteArray(64 * 1024)
+    /** Count [input]'s bytes without retaining them, giving up at [MAX_RESPONSE_BYTES]. */
+    private fun drainCounting(input: InputStream): Long {
+        val chunk = ByteArray(8 * 1024)
         var total = 0L
-        while (true) {
+        while (total <= MAX_RESPONSE_BYTES) {
             val n = input.read(chunk)
             if (n < 0) break
             total += n
-            if (total > MAX_RESPONSE_BYTES) throw IOException("relay response exceeds $MAX_RESPONSE_BYTES bytes")
-            buffer.write(chunk, 0, n)
         }
-        return buffer.toByteArray()
+        return total
+    }
+
+    /**
+     * The relay is a separate, not-fully-trusted party: even though decryption is streamed with
+     * bounded memory, cap the total bytes it can feed us per response so a rogue relay cannot
+     * stream forever (into our disk or time). [MAX_RESPONSE_BYTES] leaves generous headroom over
+     * the real bundle size.
+     */
+    private class BoundedInputStream(
+        input: InputStream,
+    ) : FilterInputStream(input) {
+        private var total = 0L
+
+        override fun read(): Int = super.read().also { if (it >= 0) count(1) }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int = super.read(b, off, len).also { if (it > 0) count(it) }
+
+        private fun count(n: Int) {
+            total += n
+            if (total > MAX_RESPONSE_BYTES) throw IOException("relay response exceeds $MAX_RESPONSE_BYTES bytes")
+        }
     }
 
     companion object {
@@ -118,7 +149,7 @@ class OhttpTransport : UpdateTransport {
 
         private const val TIMEOUT_MS = 15_000
 
-        /** Hard ceiling on a single relay response (128MB). */
+        /** Hard ceiling on the total wire bytes of a single relay response (128MB). */
         private const val MAX_RESPONSE_BYTES = 128L * 1024 * 1024
 
         fun sha256Hex(bytes: ByteArray): String =

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/OhttpTransport.kt
@@ -16,6 +16,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
 import java.util.Base64
+import java.util.zip.GZIPInputStream
 
 /**
  * Oblivious HTTP transport for the indicator update feed, using the chunked variant
@@ -49,7 +50,7 @@ class OhttpTransport : UpdateTransport {
                 scheme = TARGET_SCHEME,
                 authority = TARGET_AUTHORITY,
                 path = path,
-                headers = listOf("accept" to "*/*"),
+                headers = listOf("accept" to "*/*", "accept-encoding" to "gzip"),
             ),
         )
         val body = request.header + request.sealFinalChunk(inner)
@@ -78,14 +79,28 @@ class OhttpTransport : UpdateTransport {
                 throw IOException("unexpected relay content type ${conn.contentType}")
             }
             conn.inputStream.use { raw ->
-                val plaintext = request.decapsulateChunkedResponse(BoundedInputStream(raw))
+                val plaintext = request.decapsulateChunkedResponse(BoundedInputStream(raw, MAX_RESPONSE_BYTES, "relay response"))
                 val response = decodeResponseStream(plaintext)
                 Log.i(TAG, "GET $path -> inner status ${response.statusCode}")
-                return consume(response.statusCode, response.body)
+                return consume(response.statusCode, decoded(response.headers, response.body))
             }
         } finally {
             conn.disconnect()
         }
+    }
+
+    /**
+     * Apply the response's content-encoding. Only gzip is offered ([accept-encoding]); the body is
+     * streamed through the decompressor and bounded, since a small gzip can expand hugely and the
+     * bytes are unverified until the hash check downstream. An unencoded body passes through.
+     */
+    internal fun decoded(
+        headers: List<Pair<String, String>>,
+        body: InputStream,
+        maxBytes: Long = MAX_DECOMPRESSED_BYTES,
+    ): InputStream {
+        val gzip = headers.any { it.first.equals("content-encoding", ignoreCase = true) && it.second.trim().equals("gzip", ignoreCase = true) }
+        return if (gzip) BoundedInputStream(GZIPInputStream(body), maxBytes, "decompressed response") else body
     }
 
     /** Count [input]'s bytes without retaining them, giving up at [MAX_RESPONSE_BYTES]. */
@@ -101,13 +116,14 @@ class OhttpTransport : UpdateTransport {
     }
 
     /**
-     * The relay is a separate, not-fully-trusted party: even though decryption is streamed with
-     * bounded memory, cap the total bytes it can feed us per response so a rogue relay cannot
-     * stream forever (into our disk or time). [MAX_RESPONSE_BYTES] leaves generous headroom over
-     * the real bundle size.
+     * Caps how many bytes [input] can yield, throwing past [limit]. Used on the wire (a rogue relay
+     * must not stream forever) and on the decompressed body (a small gzip must not expand without
+     * bound). Both limits leave generous headroom over the real bundle size.
      */
-    private class BoundedInputStream(
+    internal class BoundedInputStream(
         input: InputStream,
+        private val limit: Long,
+        private val what: String,
     ) : FilterInputStream(input) {
         private var total = 0L
 
@@ -121,7 +137,7 @@ class OhttpTransport : UpdateTransport {
 
         private fun count(n: Int) {
             total += n
-            if (total > MAX_RESPONSE_BYTES) throw IOException("relay response exceeds $MAX_RESPONSE_BYTES bytes")
+            if (total > limit) throw IOException("$what exceeds $limit bytes")
         }
     }
 
@@ -151,6 +167,9 @@ class OhttpTransport : UpdateTransport {
 
         /** Hard ceiling on the total wire bytes of a single relay response (128MB). */
         private const val MAX_RESPONSE_BYTES = 128L * 1024 * 1024
+
+        /** Hard ceiling on a gzip-decompressed response body (128MB). */
+        private const val MAX_DECOMPRESSED_BYTES = 128L * 1024 * 1024
 
         fun sha256Hex(bytes: ByteArray): String =
             MessageDigest.getInstance("SHA-256").digest(bytes)

--- a/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateTransport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/update/UpdateTransport.kt
@@ -1,6 +1,7 @@
 package org.osservatorionessuno.bugbane.update
 
 import org.osservatorionessuno.libbhttp.BhttpResponse
+import java.io.InputStream
 
 /**
  * Minimal transport seam the updater fetches over. The production implementation is [OhttpTransport]
@@ -8,5 +9,16 @@ import org.osservatorionessuno.libbhttp.BhttpResponse
  * a network or HPKE.
  */
 interface UpdateTransport {
+    /** Whole-body GET, for small resources (update.json, deltas). */
     fun get(path: String): BhttpResponse
+
+    /**
+     * GET whose response body [consume] reads as a stream while it downloads, for the full bundle —
+     * it is never held in memory. A body read that throws means tampering or truncation; reaching
+     * EOF means the response arrived complete.
+     */
+    fun <T> getStream(
+        path: String,
+        consume: (statusCode: Int, body: InputStream) -> T,
+    ): T
 }

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/DeltaPatchTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/DeltaPatchTest.kt
@@ -1,7 +1,10 @@
 package org.osservatorionessuno.bugbane.update
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.security.MessageDigest
 import java.util.Base64
 
@@ -26,9 +29,28 @@ class DeltaPatchTest {
 
     @Test
     fun reproducesFullBundleBytesAndHash() {
-        val result = DeltaPatch.apply(old, delta)
+        val result = apply(old, delta)
         assertEquals(String(new, Charsets.UTF_8), String(result, Charsets.UTF_8))
         assertEquals(newSha, sha256Hex(result))
+    }
+
+    @Test
+    fun mismatchedRemovalThrows() {
+        // Byte 200 is inside bundle line 3, the first line the delta removes (and thus compares).
+        val tampered = old.copyOf().also { it[200] = 'X'.code.toByte() }
+        assertThrows(IOException::class.java) { apply(tampered, delta) }
+    }
+
+    @Test
+    fun truncatedHunkThrows() {
+        val truncated = delta.copyOfRange(0, delta.size / 2)
+        assertThrows(IOException::class.java) { apply(old, truncated) }
+    }
+
+    private fun apply(source: ByteArray, delta: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        source.inputStream().bufferedReader(Charsets.UTF_8).use { DeltaPatch.apply(it, delta, out) }
+        return out.toByteArray()
     }
 
     private fun sha256Hex(bytes: ByteArray): String =

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorStoreTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorStoreTest.kt
@@ -1,5 +1,6 @@
 package org.osservatorionessuno.bugbane.update
 
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.security.MessageDigest
 
 class IndicatorStoreTest {
 
@@ -28,7 +30,7 @@ class IndicatorStoreTest {
     }
 
     @Test
-    fun writeBundleClearsStaleIndicatorFilesAndCounts() {
+    fun adoptStagedClearsStaleIndicatorFilesAndCounts() {
         val dir = IndicatorStore(tmp).indicatorsDir
         // Pre-existing stale indicator files that a previous mechanism might have left behind.
         File(dir, "old-a.json").writeText("{}")
@@ -40,18 +42,28 @@ class IndicatorStoreTest {
             """{"id":"indicator--1"},""" + "\n" +
             """{"id":"indicator--2"}""" + "\n" +
             """],"type":"bundle"}""" + "\n").toByteArray()
-        store.writeBundle(bundle)
+        val staged = store.stage { it.write(bundle) }
+        assertEquals(2, staged.objectCount)
+        assertEquals(sha256Hex(bundle), staged.sha256)
+        store.adoptStaged(staged)
 
         val names = dir.listFiles()!!.map { it.name }.toSet()
         assertFalse("old-a.json" in names)
         assertFalse("old-b.stix2" in names)
         assertTrue("indicators.json" in names)
-        assertEquals(2, store.countObjects(bundle))
-        assertEquals(0, store.countObjects("not json".toByteArray()))
+        assertArrayEquals(bundle, store.openBundle()!!.use { it.readBytes() })
+        assertEquals(0, store.stage { it.write("not json".toByteArray()) }.also { it.discard() }.objectCount)
     }
 
     @Test
-    fun readBundleNullWhenAbsent() {
-        assertNull(IndicatorStore(tmp).readBundle())
+    fun discardedStageLeavesNoBundle() {
+        val store = IndicatorStore(tmp)
+        store.stage { it.write("candidate".toByteArray()) }.discard()
+        assertFalse(store.hasBundle())
+        assertNull(store.openBundle())
+        assertTrue(store.indicatorsDir.listFiles()!!.isEmpty())
     }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 }

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorUpdaterTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/IndicatorUpdaterTest.kt
@@ -62,12 +62,23 @@ class IndicatorUpdaterTest {
             val (status, body) = routes[path] ?: (404 to ByteArray(0))
             return BhttpResponse(status, emptyList(), body, emptyList())
         }
+        override fun <T> getStream(path: String, consume: (Int, java.io.InputStream) -> T): T {
+            requested += path
+            val (status, body) = routes[path] ?: (404 to ByteArray(0))
+            return consume(status, body.inputStream())
+        }
     }
 
     private fun store() = IndicatorStore(tmp)
 
+    private fun writeBundle(store: IndicatorStore, bundle: ByteArray) =
+        store.adoptStaged(store.stage { it.write(bundle) })
+
+    private fun readBundle(store: IndicatorStore): ByteArray? =
+        store.openBundle()?.use { it.readBytes() }
+
     private fun seed(store: IndicatorStore, version: Int, sha256: String, bundle: ByteArray, objectCount: Int) {
-        store.writeBundle(bundle)
+        writeBundle(store, bundle)
         store.writeState(IndicatorStore.State(schema = 1, version = version, sha256 = sha256, objectCount = objectCount))
     }
 
@@ -91,7 +102,7 @@ class IndicatorUpdaterTest {
         assertEquals(1, out.toVersion)
         assertFalse(out.viaDelta)
         assertEquals(5, out.newObjects)
-        assertArrayEquals(newBundle, store.readBundle())
+        assertArrayEquals(newBundle, readBundle(store))
         val s = store.readState()
         assertEquals(1, s.version)
         assertEquals(shaNew, s.sha256)
@@ -118,7 +129,7 @@ class IndicatorUpdaterTest {
     fun upToDate_usesStoredHashWithoutRecomputingLocalBundle() {
         val store = store()
         // On-disk bundle is garbage, but the stored hash matches the server: must NOT re-download.
-        store.writeBundle("not a real bundle".toByteArray())
+        writeBundle(store, "not a real bundle".toByteArray())
         store.writeState(IndicatorStore.State(schema = 1, version = 2, sha256 = shaNew, objectCount = 5))
         val t = FakeTransport().apply { route("/v1/update.json", 200, updateJson(2, shaNew)) }
 
@@ -144,7 +155,7 @@ class IndicatorUpdaterTest {
         assertTrue(out.viaDelta)
         assertEquals(1, out.fromVersion)
         assertEquals(2, out.toVersion)
-        assertArrayEquals(newBundle, store.readBundle())
+        assertArrayEquals(newBundle, readBundle(store))
         assertEquals(shaNew, store.readState().sha256)
         assertTrue(deltaPath(1, 2) in t.requested)
         assertFalse(fullPath(shaNew) in t.requested)
@@ -163,7 +174,7 @@ class IndicatorUpdaterTest {
 
         assertTrue(out is IndicatorUpdater.Outcome.Updated)
         assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
-        assertArrayEquals(newBundle, store.readBundle())
+        assertArrayEquals(newBundle, readBundle(store))
         assertTrue(deltaPath(1, 2) in t.requested)
         assertTrue(fullPath(shaNew) in t.requested)
     }
@@ -181,7 +192,7 @@ class IndicatorUpdaterTest {
 
         assertTrue(out is IndicatorUpdater.Outcome.Updated)
         assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
-        assertArrayEquals(newBundle, store.readBundle())
+        assertArrayEquals(newBundle, readBundle(store))
     }
 
     @Test
@@ -213,7 +224,7 @@ class IndicatorUpdaterTest {
         assertTrue(out is IndicatorUpdater.Outcome.Updated)
         assertFalse((out as IndicatorUpdater.Outcome.Updated).viaDelta)
         assertEquals(shaNew, store.readState().sha256)
-        assertArrayEquals(newBundle, store.readBundle())
+        assertArrayEquals(newBundle, readBundle(store))
     }
 
     @Test
@@ -227,7 +238,7 @@ class IndicatorUpdaterTest {
         assertTrue(out is IndicatorUpdater.Outcome.UnknownSchema)
         assertEquals(2, (out as IndicatorUpdater.Outcome.UnknownSchema).schema)
         // Local indicators untouched.
-        assertArrayEquals(oldBundle, store.readBundle())
+        assertArrayEquals(oldBundle, readBundle(store))
         assertEquals(3, store.readState().version)
     }
 
@@ -242,7 +253,7 @@ class IndicatorUpdaterTest {
 
         assertTrue(out is IndicatorUpdater.Outcome.Failed)
         assertEquals(0, store.readState().version)
-        assertNull(store.readBundle())
+        assertNull(readBundle(store))
     }
 
     @Test

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpFetchLiveTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpFetchLiveTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import java.security.MessageDigest
 
 /**
  * Live end-to-end fetch from the real update server over Oblivious HTTP, including the HPKE round
@@ -34,6 +35,9 @@ class OhttpFetchLiveTest {
         val meta = UpdateMetadata.parse(transport.get("/v1/update.json").body)
         val full = transport.get("/v1/${meta.sha256}.json")
         assertEquals(200, full.statusCode)
-        assertEquals(meta.sha256, OhttpTransport.sha256Hex(full.body))
+        assertEquals(meta.sha256, sha256Hex(full.body))
     }
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 }

--- a/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpTransportTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/bugbane/update/OhttpTransportTest.kt
@@ -1,0 +1,39 @@
+package org.osservatorionessuno.bugbane.update
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.zip.GZIPOutputStream
+
+// Response content-decoding: gzip bodies are transparently decompressed, an unencoded body passes
+// through, and a gzip that expands past the cap is refused (bomb guard) rather than filling memory.
+class OhttpTransportTest {
+    private val transport = OhttpTransport()
+
+    private fun gzip(bytes: ByteArray): ByteArray =
+        ByteArrayOutputStream().also { out -> GZIPOutputStream(out).use { it.write(bytes) } }.toByteArray()
+
+    @Test
+    fun `gzip response body is decompressed`() {
+        val original = ("{\"objects\":[" + "\"x\",".repeat(5000) + "\"end\"]}").toByteArray()
+        val out = transport.decoded(listOf("content-encoding" to "GZIP"), gzip(original).inputStream()).readBytes()
+        assertArrayEquals(original, out)
+    }
+
+    @Test
+    fun `unencoded body passes through unchanged`() {
+        val original = "not compressed".toByteArray()
+        val out = transport.decoded(listOf("content-type" to "application/json"), original.inputStream()).readBytes()
+        assertArrayEquals(original, out)
+    }
+
+    @Test
+    fun `gzip expanding past the cap is refused`() {
+        // 1 MiB of zeros compresses tiny but expands well past the 64 KiB cap below.
+        val bomb = gzip(ByteArray(1 shl 20))
+        val decoded = transport.decoded(listOf("content-encoding" to "gzip"), bomb.inputStream(), maxBytes = 64L * 1024)
+        assertThrows(IOException::class.java) { decoded.readBytes() }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,14 +13,13 @@ protobufPlugin        = "0.9.5"
 libadb                = "3.2.1"
 bouncycastle          = "1.84"
 work                  = "2.10.3"
-javaDiffUtils         = "4.15"
 kage                  = "0.3.0"
 json                  = "20250517"
 accompanist-permissions = "0.37.3"
 libmvt                = "c8415cd719"
-libohttp              = "1.0.0"
+libohttp              = "1.1.0"
 libohttpHpkeBc        = "1.0.1"
-libbhttp              = "1.0.0"
+libbhttp              = "1.1.0"
 
 [plugins]
 android-application   = { id = "com.android.application",            version.ref = "agp" }
@@ -54,7 +53,6 @@ protoc                            = { group = "com.google.protobuf",          na
 junit-jupiter-api                 = { group = "org.junit.jupiter",            name = "junit-jupiter-api",      version.ref = "junitJupiter" }
 junit-jupiter-engine              = { group = "org.junit.jupiter",            name = "junit-jupiter-engine",   version.ref = "junitJupiter" }
 androidx-work-runtime-ktx         = { group = "androidx.work",              name = "work-runtime-ktx",      version.ref = "work" }
-java-diff-utils                   = { group = "io.github.java-diff-utils",  name = "java-diff-utils",       version.ref = "javaDiffUtils" }
 kage                              = { group = "com.github.android-password-store", name = "kage", version.ref = "kage" }
 org-json                          = { group = "org.json",                     name = "json",                   version.ref = "json" }
 libmvt                            = { group = "com.github.osservatorionessuno", name = "libmvt", version.ref = "libmvt" }


### PR DESCRIPTION
Standard OHTTP has to encrypt everything in a single HPKE ciphertext, and standard HPKE libraries do the whole operation in-memory. Since the IOC list is already ~8MB and might grow significantly in the future, it's better to support [chunked OHTTP](https://datatracker.ietf.org/doc/draft-ietf-ohai-chunked-ohttp/). It has been implemented and tested both in [libohttp](https://github.com/osservatorionessuno/libohttp/commit/def3c5e214e52929f4641becf7e117140bbfe00b) and [libbhttp](https://github.com/osservatorionessuno/libbhttp/commit/c4e6a042555e978f80d96ce804a97c63fc412abd).