### PR TITLE
Add hash collection for all the artifacts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -186,3 +186,11 @@ protobuf {
         }
     }
 }
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "failed", "skipped", "standardOut", "standardError")
+        showStandardStreams = true
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/ArtifactHashes.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/ArtifactHashes.kt
@@ -3,17 +3,53 @@ package org.osservatorionessuno.qf.storage
 /** SHA-256 manifest for artifacts in an acquisition archive. */
 const val HASHES_FILE: String = "hashes.csv"
 
+/*
+    Same "path,sha256" format as androidqf's hashes.csv: RFC 4180 quoting
+    (as produced by Go's encoding/csv) for paths containing commas, quotes,
+    or newlines.
+*/
 object ArtifactHashes {
-    fun formatLine(path: String, sha256: String): String = "$path,$sha256\n"
+    fun formatLine(path: String, sha256: String): String = "${quote(path)},$sha256\n"
 
-    fun parse(content: String): List<Pair<String, String>> =
-        content.lineSequence()
-            .map { it.trim() }
-            .filter { it.isNotEmpty() }
-            .map { line ->
-                val comma = line.indexOf(',')
-                require(comma > 0) { "Invalid hashes.csv line: $line" }
-                line.substring(0, comma) to line.substring(comma + 1)
+    /** @throws IllegalArgumentException on malformed content; treat as an integrity failure. */
+    fun parse(content: String): List<Pair<String, String>> {
+        val records = mutableListOf<String>()
+        val record = StringBuilder()
+        var inQuotes = false
+        for (ch in content) {
+            when {
+                ch == '"' -> {
+                    inQuotes = !inQuotes
+                    record.append(ch)
+                }
+                (ch == '\n' || ch == '\r') && !inQuotes -> {
+                    if (record.isNotEmpty()) records.add(record.toString())
+                    record.clear()
+                }
+                else -> record.append(ch)
             }
-            .toList()
+        }
+        require(!inQuotes) { "Unterminated quote in hashes.csv" }
+        if (record.isNotEmpty()) records.add(record.toString())
+        return records.map { parseRecord(it) }
+    }
+
+    private fun parseRecord(record: String): Pair<String, String> {
+        // The hash is the fixed-format last field, so the separator is the
+        // last comma even if an unquoted path contains commas.
+        val comma = record.lastIndexOf(',')
+        require(comma > 0) { "Invalid hashes.csv record: $record" }
+        return unquote(record.substring(0, comma)) to record.substring(comma + 1)
+    }
+
+    private fun quote(field: String): String =
+        if (field.none { it == ',' || it == '"' || it == '\n' || it == '\r' }) field
+        else "\"${field.replace("\"", "\"\"")}\""
+
+    private fun unquote(field: String): String =
+        if (field.length >= 2 && field.startsWith('"') && field.endsWith('"')) {
+            field.substring(1, field.length - 1).replace("\"\"", "\"")
+        } else {
+            field
+        }
 }

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/ArtifactHashes.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/ArtifactHashes.kt
@@ -1,0 +1,19 @@
+package org.osservatorionessuno.qf.storage
+
+/** SHA-256 manifest for artifacts in an acquisition archive. */
+const val HASHES_FILE: String = "hashes.csv"
+
+object ArtifactHashes {
+    fun formatLine(path: String, sha256: String): String = "$path,$sha256\n"
+
+    fun parse(content: String): List<Pair<String, String>> =
+        content.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { line ->
+                val comma = line.indexOf(',')
+                require(comma > 0) { "Invalid hashes.csv line: $line" }
+                line.substring(0, comma) to line.substring(comma + 1)
+            }
+            .toList()
+}

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/DigestingOutputStream.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/DigestingOutputStream.kt
@@ -1,0 +1,45 @@
+package org.osservatorionessuno.qf.storage
+
+import java.io.IOException
+import java.io.OutputStream
+import java.security.MessageDigest
+
+/**
+ * Streams bytes to [delegate] while computing a SHA-256 digest.
+ * When [onClosed] is set, it receives the hex digest after [delegate] is closed.
+ */
+class DigestingOutputStream(
+    private val delegate: OutputStream,
+    private val onClosed: ((sha256Hex: String) -> Unit)? = null,
+) : OutputStream() {
+    private val digest = MessageDigest.getInstance("SHA-256")
+    private var closed = false
+
+    var bytesWritten: Long = 0
+        private set
+
+    @Throws(IOException::class)
+    override fun write(b: Int) {
+        digest.update(b.toByte())
+        delegate.write(b)
+        bytesWritten++
+    }
+
+    @Throws(IOException::class)
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        digest.update(b, off, len)
+        delegate.write(b, off, len)
+        bytesWritten += len
+    }
+
+    @Throws(IOException::class)
+    override fun flush() = delegate.flush()
+
+    @Throws(IOException::class)
+    override fun close() {
+        if (closed) return
+        closed = true
+        delegate.close()
+        onClosed?.invoke(digest.digest().joinToString("") { "%02x".format(it) })
+    }
+}

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
@@ -1,5 +1,6 @@
 package org.osservatorionessuno.qf.storage
 
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -27,13 +28,17 @@ class EncryptedAcquisitionWriter(
     private val writer = AgeZipArchiveWriter(FileOutputStream(File(acquisitionDir, ARCHIVE_FILE)), vault)
     private val writtenPaths = mutableSetOf<String>()
     private var indexWritten = false
+    private val hashManifest = ByteArrayOutputStream()
+    private var hashManifestArchived = false
 
     override fun openArtifact(path: String, modifiedTime: Long?): OutputStream {
         val name = normalizeArtifactPath(path)
         if (isReservedArtifact(name) || !writtenPaths.add(name)) {
             throw IOException("Artifact already exists: $path")
         }
-        return writer.putEntry(name, modifiedTime)
+        return DigestingOutputStream(writer.putEntry(name, modifiedTime)) { sha256 ->
+            hashManifest.write(ArtifactHashes.formatLine(name, sha256).toByteArray(Charsets.UTF_8))
+        }
     }
 
     override fun artifactExists(path: String): Boolean {
@@ -41,17 +46,27 @@ class EncryptedAcquisitionWriter(
         return isReservedArtifact(name) || name in writtenPaths
     }
 
-    override fun close(): Unit = writer.close()
+    override fun close() {
+        archiveHashManifestIfNeeded()
+        writer.close()
+    }
 
     /** Write [index] as the final [METADATA_FILE] zip entry (before [close]). */
     @Throws(IOException::class)
     fun writeIndex(index: AcquisitionIndex) {
         check(!indexWritten) { "index already written" }
+        archiveHashManifestIfNeeded()
         val json = Utils.toJsonString(index.toJsonObject()).toByteArray(Charsets.UTF_8)
         writer.putEntry(METADATA_FILE).use { it.write(json) }
         indexWritten = true
         // Keep a copy in plaintext so acquisitions can be listed without unlocking the Keystore.
         File(acquisitionDir, METADATA_FILE).writeText(Utils.toJsonString(index.toJsonObject()), Charsets.UTF_8)
+    }
+
+    private fun archiveHashManifestIfNeeded() {
+        if (hashManifestArchived || hashManifest.size() == 0) return
+        writer.putEntry(HASHES_FILE).use { hashManifest.writeTo(it) }
+        hashManifestArchived = true
     }
 }
 
@@ -81,6 +96,17 @@ class EncryptedAcquisitionReader(
             )
         }
         return index
+    }
+
+    fun readHashes(): List<Pair<String, String>>? {
+        var hashes: List<Pair<String, String>>? = null
+        forEachArtifact { artifact ->
+            if (artifact.path != HASHES_FILE) return@forEachArtifact
+            hashes = ArtifactHashes.parse(
+                artifact.reopenable.openStream().bufferedReader().readText(),
+            )
+        }
+        return hashes
     }
 
     override fun close(): Unit {
@@ -114,6 +140,7 @@ private fun normalizeArtifactPath(path: String): String {
 */
 private fun isReservedArtifact(name: String): Boolean {
     if (name == METADATA_FILE) return true
+    if (name == HASHES_FILE) return true
     if (name.startsWith("${AcquisitionIndex.ANALYSIS_DIR}/")) return true
     return false
 }

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
@@ -32,6 +32,7 @@ class EncryptedAcquisitionWriter(
     private var hashManifestArchived = false
 
     override fun openArtifact(path: String, modifiedTime: Long?): OutputStream {
+        check(!hashManifestArchived) { "hash manifest already written" }
         val name = normalizeArtifactPath(path)
         if (isReservedArtifact(name) || !writtenPaths.add(name)) {
             throw IOException("Artifact already exists: $path")
@@ -92,7 +93,7 @@ class EncryptedAcquisitionReader(
         forEachArtifact { artifact ->
             if (artifact.path != METADATA_FILE) return@forEachArtifact
             index = AcquisitionIndex.fromJsonObject(
-                JSONObject(artifact.reopenable.openStream().bufferedReader().readText()),
+                JSONObject(artifact.reopenable.openStream().bufferedReader().use { it.readText() }),
             )
         }
         return index
@@ -103,7 +104,7 @@ class EncryptedAcquisitionReader(
         forEachArtifact { artifact ->
             if (artifact.path != HASHES_FILE) return@forEachArtifact
             hashes = ArtifactHashes.parse(
-                artifact.reopenable.openStream().bufferedReader().readText(),
+                artifact.reopenable.openStream().bufferedReader().use { it.readText() },
             )
         }
         return hashes

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
@@ -1,0 +1,61 @@
+package org.osservatorionessuno.qf.storage
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.osservatorionessuno.qf.crypto.InMemoryKeyVault
+import java.io.File
+import java.security.MessageDigest
+
+class ArtifactHashesTest {
+
+    @Test
+    fun `parse matches example hashes csv format`() {
+        val content = """
+            getprop.txt,a7adc0aeb573a9c881d7379f87444359afc4bf2515a0378de89e3d26e3473d8b
+            env.txt,7fec02dc1108aa9b2a53337c11c7f2980947da6e294c35f1e49dddb5d5fa5c65
+
+        """.trimIndent()
+
+        val parsed = ArtifactHashes.parse(content)
+        assertEquals(2, parsed.size)
+        assertEquals("getprop.txt" to "a7adc0aeb573a9c881d7379f87444359afc4bf2515a0378de89e3d26e3473d8b", parsed[0])
+        assertEquals("env.txt" to "7fec02dc1108aa9b2a53337c11c7f2980947da6e294c35f1e49dddb5d5fa5c65", parsed[1])
+    }
+
+    @Test
+    fun `formatLine is path comma sha256 newline`() {
+        assertEquals(
+            "getprop.txt,abc\n",
+            ArtifactHashes.formatLine("getprop.txt", "abc"),
+        )
+    }
+}
+
+class DigestingOutputStreamTest {
+
+    @Test
+    fun `computes sha256 of streamed bytes and invokes onClosed`() {
+        val data = "ro.product.model=Pixel 7\n".toByteArray()
+        val collected = java.io.ByteArrayOutputStream()
+        var closedHash: String? = null
+        DigestingOutputStream(collected) { closedHash = it }.use { it.write(data) }
+        assertEquals(closedHash, "891766a4ce3c09c34a50c8fd41bfb1785144eb13d74b07f2732e8325b9e2cc34")
+        assertEquals(data.size, collected.size())
+    }
+}
+
+class EncryptedAcquisitionHashesTest {
+
+    @Test
+    fun `hashes csv is reserved from module artifacts`() {
+        val dir = createTempDir(prefix = "hashes-reserved-").also { it.deleteOnExit() }
+        val vault = InMemoryKeyVault()
+        EncryptedAcquisitionWriter(dir, vault).use { writer ->
+            val error = runCatching { writer.openArtifact(HASHES_FILE) }.exceptionOrNull()
+            assertNotNull(error)
+            assertTrue(error!!.message!!.contains(HASHES_FILE))
+        }
+    }
+}

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
@@ -4,32 +4,50 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.osservatorionessuno.qf.crypto.InMemoryKeyVault
-import java.io.File
+import java.nio.file.Files
 import java.security.MessageDigest
+
+private fun sha256Hex(data: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(data).joinToString("") { "%02x".format(it) }
 
 class ArtifactHashesTest {
 
     @Test
-    fun `parse matches example hashes csv format`() {
-        val content = """
-            getprop.txt,a7adc0aeb573a9c881d7379f87444359afc4bf2515a0378de89e3d26e3473d8b
-            env.txt,7fec02dc1108aa9b2a53337c11c7f2980947da6e294c35f1e49dddb5d5fa5c65
-
-        """.trimIndent()
+    fun `parse matches androidqf hashes csv format`() {
+        val hashA = "a7adc0aeb573a9c881d7379f87444359afc4bf2515a0378de89e3d26e3473d8b"
+        val hashB = "7fec02dc1108aa9b2a53337c11c7f2980947da6e294c35f1e49dddb5d5fa5c65"
+        val content = "getprop.txt,$hashA\n\"logs/anr,with,commas.txt\",$hashB\n"
 
         val parsed = ArtifactHashes.parse(content)
         assertEquals(2, parsed.size)
-        assertEquals("getprop.txt" to "a7adc0aeb573a9c881d7379f87444359afc4bf2515a0378de89e3d26e3473d8b", parsed[0])
-        assertEquals("env.txt" to "7fec02dc1108aa9b2a53337c11c7f2980947da6e294c35f1e49dddb5d5fa5c65", parsed[1])
+        assertEquals("getprop.txt" to hashA, parsed[0])
+        assertEquals("logs/anr,with,commas.txt" to hashB, parsed[1])
     }
 
     @Test
-    fun `formatLine is path comma sha256 newline`() {
+    fun `formatLine quotes paths that need it`() {
+        val hash = "a".repeat(64)
+        assertEquals("getprop.txt,$hash\n", ArtifactHashes.formatLine("getprop.txt", hash))
         assertEquals(
-            "getprop.txt,abc\n",
-            ArtifactHashes.formatLine("getprop.txt", "abc"),
+            "\"logs/anr,trace.txt\",$hash\n",
+            ArtifactHashes.formatLine("logs/anr,trace.txt", hash),
         )
+    }
+
+    @Test
+    fun `quoted quotes and newlines in paths round-trip through format and parse`() {
+        val hash = "a".repeat(64)
+        for (path in listOf("""logs/we"ird.txt""", "logs/multi\nline.txt")) {
+            assertEquals(listOf(path to hash), ArtifactHashes.parse(ArtifactHashes.formatLine(path, hash)))
+        }
+    }
+
+    @Test
+    fun `parse rejects malformed records`() {
+        assertThrows<IllegalArgumentException> { ArtifactHashes.parse("no-comma-at-all") }
+        assertThrows<IllegalArgumentException> { ArtifactHashes.parse("\"unterminated.txt,${"a".repeat(64)}") }
     }
 }
 
@@ -48,14 +66,48 @@ class DigestingOutputStreamTest {
 
 class EncryptedAcquisitionHashesTest {
 
+    private fun tempDir() = Files.createTempDirectory("hashes-test-").toFile().also { it.deleteOnExit() }
+
     @Test
     fun `hashes csv is reserved from module artifacts`() {
-        val dir = createTempDir(prefix = "hashes-reserved-").also { it.deleteOnExit() }
-        val vault = InMemoryKeyVault()
-        EncryptedAcquisitionWriter(dir, vault).use { writer ->
+        val dir = tempDir()
+        EncryptedAcquisitionWriter(dir, InMemoryKeyVault()).use { writer ->
             val error = runCatching { writer.openArtifact(HASHES_FILE) }.exceptionOrNull()
             assertNotNull(error)
             assertTrue(error!!.message!!.contains(HASHES_FILE))
         }
+    }
+
+    @Test
+    fun `written hashes round-trip and match the artifact contents`() {
+        val dir = tempDir()
+        val vault = InMemoryKeyVault()
+        val artifacts = mapOf(
+            "getprop.txt" to "ro.product.model=Pixel 7\n".toByteArray(),
+            "logs/anr/trace.txt" to ByteArray(1 shl 16) { it.toByte() },
+            // Hostile device filename: quoting must keep it one manifest record.
+            "logs/innocent.txt,${"0".repeat(64)}\nbugreport.zip" to "boom".toByteArray(),
+        )
+        EncryptedAcquisitionWriter(dir, vault).use { writer ->
+            artifacts.forEach { (path, data) ->
+                writer.useArtifact(path) { it.write(data) }
+            }
+        }
+
+        val hashes = EncryptedAcquisitionReader(dir, vault).use { it.readHashes() }
+        assertNotNull(hashes)
+        assertEquals(
+            artifacts.mapValues { sha256Hex(it.value) },
+            hashes!!.toMap(),
+        )
+    }
+
+    @Test
+    fun `artifacts cannot be added after the manifest is archived`() {
+        val dir = tempDir()
+        val writer = EncryptedAcquisitionWriter(dir, InMemoryKeyVault())
+        writer.useArtifact("getprop.txt") { it.write(1) }
+        writer.close()
+        assertThrows<IllegalStateException> { writer.openArtifact("late.txt") }
     }
 }


### PR DESCRIPTION
This PR adds support to collecting artifact hashes (hashes.csv) by wrapping openArtifact with a DigestingOutputStream.
When data is written to an artifact (added to the AgeZipArchiveWriter) everything is proxied by the Digesting class that perform sha256 on the archived data.

However, there is a big throwback: at the moment the hashes.csv file cannot be written sequentially because only one reference to a zip entry can be kept at a time. So it is buffered in RAM and written in full at the end.
Probably can be done sequentially with a big refactoring 🌵 