### PR TITLE
Revamp scanning screen

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionsScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionsScreen.kt
@@ -2,8 +2,6 @@ package org.osservatorionessuno.bugbane.screens
 
 import android.content.Intent
 import android.widget.Toast
-import androidx.compose.animation.*
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -23,8 +21,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.DateFormat
 import java.time.Instant
@@ -45,8 +45,6 @@ fun AcquisitionsScreen() {
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var acquisitionItems by remember { mutableStateOf(listOf<AcquisitionItem>()) }
-    var pendingDeletion by remember { mutableStateOf<AcquisitionItem?>(null) }
-    var isUndoClicked by remember { mutableStateOf(false) }
     var showDeleteConfirmDialog by remember { mutableStateOf<AcquisitionItem?>(null) }
 
     fun loadAcquisitions() {
@@ -66,75 +64,30 @@ fun AcquisitionsScreen() {
         }?.sortedByDescending { it.completed } ?: emptyList()
     }
 
-    fun deleteItem(item: AcquisitionItem) {
-        item.dir.deleteRecursively()
-        loadAcquisitions()
-        pendingDeletion = null
-        
-        // Show "deleted" snackbar without undo button
-        scope.launch {
-            snackbarHostState.showSnackbar(
-                message = context.getString(R.string.acquisitions_deleted_message, item.name),
-                duration = SnackbarDuration.Short,
-                withDismissAction = false
-            )
-        }
-    }
-
     fun handleDelete(item: AcquisitionItem) {
         // Show confirmation dialog first
         showDeleteConfirmDialog = item
     }
-    
+
     fun confirmDelete(item: AcquisitionItem) {
         showDeleteConfirmDialog = null
-        // Reset undo flag and set pending deletion
-        isUndoClicked = false
-        pendingDeletion = item
-        
-        // Show snackbar and handle deletion based on result
         scope.launch {
-            val result = snackbarHostState.showSnackbar(
-                message = context.getString(R.string.acquisitions_delete_message, item.name),
-                duration = SnackbarDuration.Short,
-                withDismissAction = true
-            )
-            
-            // Only delete if snackbar was dismissed by timeout and undo was not clicked
-            if (result == SnackbarResult.Dismissed && !isUndoClicked && pendingDeletion == item) {
-                deleteItem(item)
+            // Finish the delete even if the user leaves the screen.
+            withContext(NonCancellable + Dispatchers.IO) {
+                item.dir.deleteRecursively()
             }
+            loadAcquisitions()
+            snackbarHostState.showSnackbar(
+                message = context.getString(R.string.acquisitions_deleted_message, item.name),
+                duration = SnackbarDuration.Short,
+            )
         }
-    }
-
-    fun handleUndo() {
-        isUndoClicked = true
-        pendingDeletion = null
     }
 
     LaunchedEffect(Unit) { loadAcquisitions() }
 
     Scaffold(
-        snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState) { snackbarData ->
-                Snackbar(
-                    action = if (snackbarData.visuals.withDismissAction) {
-                        {
-                            TextButton(
-                                onClick = {
-                                    snackbarData.dismiss()
-                                    handleUndo()
-                                }
-                            ) {
-                                Text(stringResource(R.string.acquisitions_undo))
-                            }
-                        }
-                    } else null
-                ) {
-                    Text(snackbarData.visuals.message)
-                }
-            }
-        }
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -177,48 +130,40 @@ fun AcquisitionsScreen() {
                     items = acquisitionItems,
                     key = { it.dir.absolutePath }
                 ) { item ->
-                    AnimatedVisibility(
-                        visible = item != pendingDeletion,
-                        exit = fadeOut(animationSpec = tween(300)) + 
-                               shrinkVertically(animationSpec = tween(300)),
-                        enter = fadeIn(animationSpec = tween(300)) + 
-                               expandVertically(animationSpec = tween(300))
-                    ) {
-                        AcquisitionItemRow(
-                            item = item,
-                            onClick = {
-                                val intent = Intent(context, AcquisitionActivity::class.java).apply {
-                                    putExtra(AcquisitionActivity.EXTRA_PATH, item.dir.absolutePath)
-                                }
-                                context.startActivity(intent)
-                            },
-                            onRename = { newName ->
-                                val invalid = newName.contains('/') || newName.contains("\\") ||
-                                    newName == "." || newName == ".."
-                                if (invalid) {
+                    AcquisitionItemRow(
+                        item = item,
+                        onClick = {
+                            val intent = Intent(context, AcquisitionActivity::class.java).apply {
+                                putExtra(AcquisitionActivity.EXTRA_PATH, item.dir.absolutePath)
+                            }
+                            context.startActivity(intent)
+                        },
+                        onRename = { newName ->
+                            val invalid = newName.contains('/') || newName.contains("\\") ||
+                                newName == "." || newName == ".."
+                            if (invalid) {
+                                Toast.makeText(
+                                    context,
+                                    R.string.acquisitions_rename_invalid,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            } else {
+                                val newDir = File(item.dir.parentFile, newName)
+                                if (!newDir.exists() && item.dir.renameTo(newDir)) {
+                                    loadAcquisitions()
+                                } else {
                                     Toast.makeText(
                                         context,
-                                        R.string.acquisitions_rename_invalid,
+                                        R.string.acquisitions_rename_failed,
                                         Toast.LENGTH_SHORT
                                     ).show()
-                                } else {
-                                    val newDir = File(item.dir.parentFile, newName)
-                                    if (!newDir.exists() && item.dir.renameTo(newDir)) {
-                                        loadAcquisitions()
-                                    } else {
-                                        Toast.makeText(
-                                            context,
-                                            R.string.acquisitions_rename_failed,
-                                            Toast.LENGTH_SHORT
-                                        ).show()
-                                    }
                                 }
-                            },
-                            onDelete = {
-                                handleDelete(item)
                             }
-                        )
-                    }
+                        },
+                        onDelete = {
+                            handleDelete(item)
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -301,18 +301,39 @@ fun ScanScreen() {
                         ),
                         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
                     ) {
-                        Text(
-                            text = stringResource(
-                                R.string.scan_acquisition_failed_message,
-                                failed.joinToString(", ") { formatModuleDisplayName(it) },
-                            ),
-                            modifier = Modifier.padding(16.dp),
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    R.string.scan_acquisition_failed_message,
+                                    failed.joinToString(", ") { formatModuleDisplayName(it) },
+                                ),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(vertical = 16.dp),
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            IconButton(
+                                onClick = { AcquisitionProgressTracker.dismissFailedModules() }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = stringResource(R.string.scan_disable_dialog_close_button),
+                                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                                )
+                            }
+                        }
                     }
                     Button(
-                        onClick = { AcquisitionProgressTracker.dismissFailedModules() },
+                        onClick = {
+                            AcquisitionProgressTracker.dismissFailedModules()
+                            startAcquisition()
+                        },
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text(

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -122,7 +123,18 @@ private fun ScanModuleList(
     modules: List<AcquisitionProgressTracker.ModuleProgress>,
     modifier: Modifier = Modifier,
 ) {
+    val listState = rememberLazyListState()
+    val runningIndex = modules.indexOfFirst { it.status == ModuleScanStatus.Running }
+
+    // Follow the running module, unless the user is scrolling.
+    LaunchedEffect(runningIndex) {
+        if (runningIndex >= 0 && !listState.isScrollInProgress) {
+            listState.animateScrollToItem(runningIndex)
+        }
+    }
+
     LazyColumn(
+        state = listState,
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(bottom = 16.dp),

--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -2,16 +2,19 @@ package org.osservatorionessuno.bugbane.screens
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -19,9 +22,11 @@ import androidx.compose.ui.platform.LocalConfiguration
 import android.content.res.Configuration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import org.osservatorionessuno.bugbane.R
@@ -32,13 +37,151 @@ import org.osservatorionessuno.bugbane.components.LayeredProgressIndicator
 import org.osservatorionessuno.bugbane.INTENT_EXIT_BACKPRESS
 import org.osservatorionessuno.cadb.AdbState
 import org.osservatorionessuno.bugbane.utils.AcquisitionProgressTracker
+import org.osservatorionessuno.bugbane.utils.AcquisitionProgressTracker.ModuleScanStatus
 import org.osservatorionessuno.bugbane.utils.AppState
+import org.osservatorionessuno.bugbane.utils.Keys
 import org.osservatorionessuno.bugbane.utils.ViewModelFactory
 import org.osservatorionessuno.bugbane.utils.Utils
 import java.io.File
 
-private const val TAG = "ScanScreen"
 private const val BETA_COUNTDOWN_SECONDS = 10
+
+private fun formatModuleDisplayName(name: String): String =
+    name.split('_')
+        .joinToString(" ") { word ->
+            word.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        }
+
+@Composable
+private fun ScanModuleCard(
+    name: String,
+    status: ModuleScanStatus,
+    bytes: Long,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = formatModuleDisplayName(name),
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+                )
+                if (status != ModuleScanStatus.Waiting) {
+                    Text(
+                        text = " ${Utils.formatBytes(bytes)}",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontStyle = FontStyle.Italic),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
+            ModuleStatusIcon(status)
+        }
+    }
+}
+
+@Composable
+private fun ModuleStatusIcon(status: ModuleScanStatus) {
+    when (status) {
+        ModuleScanStatus.Completed -> Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(22.dp),
+        )
+        ModuleScanStatus.Running -> CircularProgressIndicator(
+            modifier = Modifier.size(22.dp),
+            strokeWidth = 2.dp,
+        )
+        ModuleScanStatus.Error -> Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(22.dp),
+        )
+        ModuleScanStatus.Waiting -> Spacer(modifier = Modifier.size(22.dp))
+    }
+}
+
+@Composable
+private fun ScanModuleList(
+    modules: List<AcquisitionProgressTracker.ModuleProgress>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(bottom = 16.dp),
+    ) {
+        items(modules, key = { it.name }) { module ->
+            ScanModuleCard(
+                name = module.name,
+                status = module.status,
+                bytes = module.bytes,
+            )
+        }
+    }
+}
+
+/**
+ * Beta gate dialog. [deadlineMs] is a wall-clock deadline shared via rememberSaveable
+ * so rotation / reopen resumes the same countdown.
+ */
+@Composable
+private fun BetaWarningDialog(
+    countdownMs: Long,
+    onAcknowledge: () -> Unit,
+    onQuit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var remainingSec by remember(countdownMs) {
+        mutableIntStateOf(
+            ((countdownMs - System.currentTimeMillis() + 999) / 1000).toInt().coerceAtLeast(0)
+        )
+    }
+
+    LaunchedEffect(countdownMs) {
+        while (true) {
+            val leftMs = (countdownMs - System.currentTimeMillis()).coerceAtLeast(0L)
+            remainingSec = ((leftMs + 999) / 1000).toInt()
+            if (leftMs == 0L) break
+            delay(leftMs.coerceAtMost(1000L))
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.beta_warning_title)) },
+        text = { Text(stringResource(R.string.beta_warning_message)) },
+        confirmButton = {
+            Button(onClick = onAcknowledge, enabled = remainingSec == 0) {
+                Text(
+                    if (remainingSec == 0) stringResource(R.string.beta_warning_understand)
+                    else "$remainingSec"
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onQuit) {
+                Text(stringResource(R.string.beta_warning_quit))
+            }
+        },
+    )
+}
 
 @Composable
 fun ScanScreen() {
@@ -57,14 +200,24 @@ fun ScanScreen() {
     val completedModules = AcquisitionProgressTracker.completedModules.collectAsStateWithLifecycle()
     val totalModules = AcquisitionProgressTracker.totalModules.collectAsStateWithLifecycle()
     val pendingAcquisition = AcquisitionProgressTracker.pendingAcquisition.collectAsStateWithLifecycle()
+    val failedModules = AcquisitionProgressTracker.failedModules.collectAsStateWithLifecycle()
     val showDisableDialog = AcquisitionProgressTracker.showDisableReminder.collectAsStateWithLifecycle()
 
     val isBetaVersion = context.packageName.contains("beta", ignoreCase = true)
-    var showBetaWarningDialog by remember { mutableStateOf(false) }
-    var betaCountdown by remember { mutableStateOf(BETA_COUNTDOWN_SECONDS) }
-    var betaButtonEnabled by remember { mutableStateOf(false) }
+    val appPrefs = remember {
+        context.getSharedPreferences(Keys.PREFS_NAME, Context.MODE_PRIVATE)
+    }
+    var showBetaWarningDialog by rememberSaveable { mutableStateOf(false) }
+    var betaAcknowledged by remember {
+        mutableStateOf(appPrefs.getBoolean(Keys.KEY_BETA_WARNING_ACKNOWLEDGED, false))
+    }
+    // 0 = not started yet; otherwise wall-clock end of the countdown.
+    var betaCountdownMs by rememberSaveable { mutableLongStateOf(0L) }
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    val isScanning = adbState.value == AdbState.ConnectedAcquiring || adbState.value == AdbState.Cancelling
+    val failed = failedModules.value
+    val showProgressUi = isScanning || failed != null
 
     fun startAcquisition() {
         AcquisitionProgressTracker.start(context, adbManager, File(context.filesDir, "acquisitions"))
@@ -73,6 +226,7 @@ fun ScanScreen() {
     // Navigate to a freshly finished acquisition. This also fires when the
     // screen is recreated (or the app is reopened from the completion
     // notification) while a finished acquisition is still pending.
+    // Failed modules never set pendingAcquisition, so this path is skipped.
     LaunchedEffect(pendingAcquisition.value) {
         val pending = pendingAcquisition.value ?: return@LaunchedEffect
         AcquisitionProgressTracker.consumePendingAcquisition(context)
@@ -87,7 +241,7 @@ fun ScanScreen() {
             .fillMaxSize()
             .padding(8.dp)
     ) {
-        if (adbState.value == AdbState.ConnectedAcquiring || adbState.value == AdbState.Cancelling) {
+        if (showProgressUi) {
             Column(modifier = Modifier.fillMaxSize()) {
                 if (isLandscape) {
                     Row(modifier = Modifier.weight(1f)) {
@@ -97,89 +251,103 @@ fun ScanScreen() {
                                 .fillMaxHeight(),
                             contentAlignment = Alignment.Center
                         ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                LayeredProgressIndicator(
-                                    totalModules = totalModules.value,
-                                    completedModules = completedModules.value,
-                                    size = 128.dp,
-                                    strokeWidth = 8.dp
-                                )
-                            }
+                            LayeredProgressIndicator(
+                                totalModules = totalModules.value,
+                                completedModules = completedModules.value,
+                                size = 128.dp,
+                                strokeWidth = 8.dp
+                            )
                         }
-                        LazyColumn(
+                        ScanModuleList(
+                            modules = modules.value,
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxHeight()
                                 .padding(16.dp),
-                        ) {
-                            items(modules.value) { module ->
-                                Text(
-                                    stringResource(
-                                        if (module.done) R.string.scan_module_completed else R.string.scan_module_running,
-                                        module.name,
-                                        Utils.formatBytes(module.bytes)
-                                    )
-                                )
-                            }
-                        }
+                        )
                     }
                 } else {
                     Column(modifier = Modifier.weight(1f)) {
                         Box(
                             modifier = Modifier
-                                .weight(1f)
-                                .fillMaxWidth(),
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp),
                             contentAlignment = Alignment.Center
                         ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                LayeredProgressIndicator(
-                                    totalModules = totalModules.value,
-                                    completedModules = completedModules.value,
-                                    size = 128.dp,
-                                    strokeWidth = 8.dp
-                                )
-                            }
+                            LayeredProgressIndicator(
+                                totalModules = totalModules.value,
+                                completedModules = completedModules.value,
+                                size = 96.dp,
+                                strokeWidth = 8.dp
+                            )
                         }
-                        LazyColumn(
+                        ScanModuleList(
+                            modules = modules.value,
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth()
-                                .padding(16.dp),
-                        ) {
-                            items(modules.value) { module ->
-                                Text(
-                                    stringResource(
-                                        if (module.done) R.string.scan_module_completed else R.string.scan_module_running,
-                                        module.name,
-                                        Utils.formatBytes(module.bytes)
-                                    )
-                                )
-                            }
-                        }
+                                .padding(horizontal = 8.dp),
+                        )
                     }
                 }
-                Button(
-                    onClick = { 
-                        if (adbState.value != AdbState.Cancelling) {
-                            adbManager.cancelQuickForensics()
-                        }
-                    },
-                    enabled = adbState.value != AdbState.Cancelling,
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error
-                    ),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = if (adbState.value == AdbState.Cancelling) stringResource(R.string.scan_cancelling_button) else stringResource(R.string.scan_cancel_button),
-                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                    )
+
+                if (failed != null) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.scan_acquisition_failed_message,
+                                failed.joinToString(", ") { formatModuleDisplayName(it) },
+                            ),
+                            modifier = Modifier.padding(16.dp),
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Button(
+                        onClick = { AcquisitionProgressTracker.dismissFailedModules() },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.scan_acquisition_failed_rescan),
+                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                        )
+                    }
+                } else {
+                    Button(
+                        onClick = {
+                            if (adbState.value != AdbState.Cancelling) {
+                                adbManager.cancelQuickForensics()
+                            }
+                        },
+                        enabled = adbState.value != AdbState.Cancelling,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        ),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (adbState.value == AdbState.Cancelling) {
+                                stringResource(R.string.scan_cancelling_button)
+                            } else {
+                                stringResource(R.string.scan_cancel_button)
+                            },
+                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                        )
+                    }
                 }
             }
         } else {
@@ -308,7 +476,11 @@ fun ScanScreen() {
                     onClick = {
                         when (appState.value) {
                             AppState.AdbConnected -> {
-                                if (isBetaVersion) {
+                                if (isBetaVersion && !betaAcknowledged) {
+                                    if (betaCountdownMs == 0L) {
+                                        betaCountdownMs =
+                                            System.currentTimeMillis() + BETA_COUNTDOWN_SECONDS * 1000L
+                                    }
                                     showBetaWarningDialog = true
                                     return@Button
                                 }
@@ -360,52 +532,22 @@ fun ScanScreen() {
                 }
             }
         }
-        
-        // Beta warning dialog
-        if (showBetaWarningDialog) {
-            LaunchedEffect(showBetaWarningDialog) {
-                if (showBetaWarningDialog) {
-                    betaCountdown = BETA_COUNTDOWN_SECONDS
-                    betaButtonEnabled = false
-                    for (i in betaCountdown.toInt() downTo 1) {
-                        delay(1000)
-                        betaCountdown = i - 1
-                    }
-                    betaButtonEnabled = true
-                }
-            }
 
-            AlertDialog(
-                onDismissRequest = { showBetaWarningDialog = false },
-                title = {
-                    Text(stringResource(R.string.beta_warning_title))
+        if (showBetaWarningDialog) {
+            BetaWarningDialog(
+                countdownMs = betaCountdownMs,
+                onAcknowledge = {
+                    appPrefs.edit { putBoolean(Keys.KEY_BETA_WARNING_ACKNOWLEDGED, true) }
+                    betaAcknowledged = true
+                    showBetaWarningDialog = false
+                    startAcquisition()
                 },
-                text = {
-                    Text(stringResource(R.string.beta_warning_message))
+                onQuit = {
+                    showBetaWarningDialog = false
+                    (context as? Activity)?.finishAffinity()
+                    System.exit(0)
                 },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            showBetaWarningDialog = false
-                            startAcquisition()
-                        },
-                        enabled = betaButtonEnabled
-                    ) {
-                        Text(if (betaButtonEnabled) stringResource(R.string.beta_warning_understand) else "$betaCountdown")
-                    }
-                },
-                dismissButton = {
-                    TextButton(
-                        onClick = {
-                            showBetaWarningDialog = false
-                            // Close the application
-                            (context as? Activity)?.finishAffinity()
-                            System.exit(0);
-                        }
-                    ) {
-                        Text(stringResource(R.string.beta_warning_quit))
-                    }
-                }
+                onDismiss = { showBetaWarningDialog = false },
             )
         }
     }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -150,7 +150,7 @@ object AcquisitionProgressTracker {
                     _pendingAcquisition.value = output
                 }
                 _showDisableReminder.value = true
-                autoAnalyze(appContext, output)
+                autoAnalyze(appContext, output, failed)
             }
         })
     }
@@ -160,7 +160,7 @@ object AcquisitionProgressTracker {
      * background the completion notification is deferred until the analysis
      * is done, so tapping it lands on the results.
      */
-    private fun autoAnalyze(context: Context, acquisitionDir: File) {
+    private fun autoAnalyze(context: Context, acquisitionDir: File, failed: List<String>) {
         _analyzing.value = acquisitionDir
         analysisScope.launch {
             var analyzed = false
@@ -173,8 +173,7 @@ object AcquisitionProgressTracker {
                 _analyzing.value = null
             }
             if (!isAppInForeground()) {
-                val failed = _failedModules.value
-                if (failed != null) {
+                if (failed.isNotEmpty()) {
                     postFailedNotification(context, failed)
                 } else {
                     postFinishedNotification(context, analyzed)

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -1,6 +1,7 @@
 package org.osservatorionessuno.bugbane.utils
 
 import android.Manifest
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -202,17 +203,19 @@ object AcquisitionProgressTracker {
         return state.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 
-    private fun ensureAcquisitionChannel(context: Context): NotificationManagerCompat? {
+    // Permission check and notify() must stay in the same function for lint's
+    // MissingPermission dataflow analysis.
+    private fun postAcquisitionNotification(context: Context, notification: Notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
         ) {
             Log.w(TAG, "Notification permission missing, skipping acquisition notification")
-            return null
+            return
         }
         val manager = NotificationManagerCompat.from(context)
         if (!manager.areNotificationsEnabled()) {
             Log.w(TAG, "Notifications disabled for the app; skipping acquisition notification")
-            return null
+            return
         }
         manager.createNotificationChannel(
             NotificationChannel(
@@ -221,7 +224,7 @@ object AcquisitionProgressTracker {
                 NotificationManager.IMPORTANCE_HIGH
             )
         )
-        return manager
+        manager.notify(NOTIFICATION_ID, notification)
     }
 
     private fun reopenAppIntent(context: Context): PendingIntent {
@@ -234,7 +237,6 @@ object AcquisitionProgressTracker {
     }
 
     private fun postFinishedNotification(context: Context, analyzed: Boolean) {
-        val manager = ensureAcquisitionChannel(context) ?: return
         // Reopen the app; ScanScreen consumes the pending acquisition and
         // navigates to the results.
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
@@ -251,11 +253,10 @@ object AcquisitionProgressTracker {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .build()
 
-        manager.notify(NOTIFICATION_ID, notification)
+        postAcquisitionNotification(context, notification)
     }
 
     private fun postFailedNotification(context: Context, failed: List<String>) {
-        val manager = ensureAcquisitionChannel(context) ?: return
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_bugbane_zoom)
             .setContentTitle(context.getString(R.string.notification_acquisition_failed_title))
@@ -270,6 +271,6 @@ object AcquisitionProgressTracker {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .build()
 
-        manager.notify(NOTIFICATION_ID, notification)
+        postAcquisitionNotification(context, notification)
     }
 }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -146,13 +146,10 @@ object AcquisitionProgressTracker {
                 if (failed.isNotEmpty()) {
                     Log.w(TAG, "Acquisition finished with failed modules: $failed")
                     _failedModules.value = failed
-                    if (!isAppInForeground()) {
-                        postFailedNotification(appContext, failed)
-                    }
-                    return
+                } else {
+                    _pendingAcquisition.value = output
                 }
                 _showDisableReminder.value = true
-                _pendingAcquisition.value = output
                 autoAnalyze(appContext, output)
             }
         })
@@ -176,7 +173,12 @@ object AcquisitionProgressTracker {
                 _analyzing.value = null
             }
             if (!isAppInForeground()) {
-                postFinishedNotification(context, analyzed)
+                val failed = _failedModules.value
+                if (failed != null) {
+                    postFailedNotification(context, failed)
+                } else {
+                    postFinishedNotification(context, analyzed)
+                }
             } else {
                 Log.d(TAG, "Skipping completion notification; app is in the foreground")
             }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -1,7 +1,6 @@
 package org.osservatorionessuno.bugbane.utils
 
 import android.Manifest
-import android.app.ActivityManager
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -12,6 +11,7 @@ import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import android.app.ActivityManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -45,7 +45,18 @@ object AcquisitionProgressTracker {
     private const val CHANNEL_ID = "acquisition_complete"
     private const val NOTIFICATION_ID = 2
 
-    data class ModuleProgress(val name: String, val bytes: Long, val done: Boolean)
+    enum class ModuleScanStatus {
+        Waiting,
+        Running,
+        Completed,
+        Error,
+    }
+
+    data class ModuleProgress(
+        val name: String,
+        val bytes: Long = 0L,
+        val status: ModuleScanStatus = ModuleScanStatus.Waiting,
+    )
 
     private val _modules = MutableStateFlow<List<ModuleProgress>>(emptyList())
     val modules: StateFlow<List<ModuleProgress>> = _modules.asStateFlow()
@@ -60,6 +71,13 @@ object AcquisitionProgressTracker {
     private val _pendingAcquisition = MutableStateFlow<File?>(null)
     val pendingAcquisition: StateFlow<File?> = _pendingAcquisition.asStateFlow()
 
+    /**
+     * Names of modules that failed in the last acquisition. Non-null until the
+     * UI dismisses the error; while set, the acquisition view is not opened.
+     */
+    private val _failedModules = MutableStateFlow<List<String>?>(null)
+    val failedModules: StateFlow<List<String>?> = _failedModules.asStateFlow()
+
     /** True after a successful acquisition until the user dismisses the reminder. */
     private val _showDisableReminder = MutableStateFlow(false)
     val showDisableReminder: StateFlow<Boolean> = _showDisableReminder.asStateFlow()
@@ -72,30 +90,47 @@ object AcquisitionProgressTracker {
 
     fun start(context: Context, adbManager: AdbManager, baseDir: File) {
         val appContext = context.applicationContext
-        _modules.value = emptyList()
+        _modules.value = AcquisitionRunner.MODULE_NAMES.map { ModuleProgress(it) }
         _completedModules.value = 0
-        _totalModules.value = 0
+        _totalModules.value = AcquisitionRunner.MODULE_NAMES.size
         _pendingAcquisition.value = null
+        _failedModules.value = null
 
         adbManager.runQuickForensics(baseDir, object : AcquisitionRunner.ProgressListener {
             override fun onModuleStart(name: String, completed: Int, total: Int) {
                 _totalModules.value = total
-                _modules.update { it + ModuleProgress(name, 0L, false) }
+                _modules.update { list ->
+                    if (list.any { it.name == name }) {
+                        list.map {
+                            if (it.name == name) it.copy(bytes = 0L, status = ModuleScanStatus.Running)
+                            else it
+                        }
+                    } else {
+                        list + ModuleProgress(name, 0L, ModuleScanStatus.Running)
+                    }
+                }
             }
 
             override fun onModuleProgress(name: String, bytes: Long) {
                 _modules.update { list ->
-                    list.map { if (it.name == name && !it.done) it.copy(bytes = bytes) else it }
+                    list.map {
+                        if (it.name == name && it.status == ModuleScanStatus.Running) {
+                            it.copy(bytes = bytes)
+                        } else {
+                            it
+                        }
+                    }
                 }
             }
 
-            override fun onModuleComplete(name: String, completed: Int, total: Int) {
+            override fun onModuleComplete(name: String, completed: Int, total: Int, success: Boolean) {
                 _completedModules.value = completed
+                val status = if (success) ModuleScanStatus.Completed else ModuleScanStatus.Error
                 _modules.update { list ->
                     if (list.any { it.name == name }) {
-                        list.map { if (it.name == name) it.copy(done = true) else it }
+                        list.map { if (it.name == name) it.copy(status = status) else it }
                     } else {
-                        list + ModuleProgress(name, 0L, true)
+                        list + ModuleProgress(name, 0L, status)
                     }
                 }
             }
@@ -104,6 +139,17 @@ object AcquisitionProgressTracker {
 
             override fun onFinished(cancelled: Boolean, output: File?) {
                 if (cancelled || output == null) return
+                val failed = _modules.value
+                    .filter { it.status == ModuleScanStatus.Error }
+                    .map { it.name }
+                if (failed.isNotEmpty()) {
+                    Log.w(TAG, "Acquisition finished with failed modules: $failed")
+                    _failedModules.value = failed
+                    if (!isAppInForeground()) {
+                        postFailedNotification(appContext, failed)
+                    }
+                    return
+                }
                 _showDisableReminder.value = true
                 _pendingAcquisition.value = output
                 autoAnalyze(appContext, output)
@@ -130,6 +176,8 @@ object AcquisitionProgressTracker {
             }
             if (!isAppInForeground()) {
                 postFinishedNotification(context, analyzed)
+            } else {
+                Log.d(TAG, "Skipping completion notification; app is in the foreground")
             }
         }
     }
@@ -144,21 +192,28 @@ object AcquisitionProgressTracker {
         _showDisableReminder.value = false
     }
 
+    fun dismissFailedModules() {
+        _failedModules.value = null
+    }
+
     private fun isAppInForeground(): Boolean {
         val state = ActivityManager.RunningAppProcessInfo()
         ActivityManager.getMyMemoryState(state)
         return state.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 
-    private fun postFinishedNotification(context: Context, analyzed: Boolean) {
+    private fun ensureAcquisitionChannel(context: Context): NotificationManagerCompat? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
         ) {
-            Log.w(TAG, "Notification permission missing, skipping completion notification")
-            return
+            Log.w(TAG, "Notification permission missing, skipping acquisition notification")
+            return null
         }
-
         val manager = NotificationManagerCompat.from(context)
+        if (!manager.areNotificationsEnabled()) {
+            Log.w(TAG, "Notifications disabled for the app; skipping acquisition notification")
+            return null
+        }
         manager.createNotificationChannel(
             NotificationChannel(
                 CHANNEL_ID,
@@ -166,16 +221,22 @@ object AcquisitionProgressTracker {
                 NotificationManager.IMPORTANCE_HIGH
             )
         )
+        return manager
+    }
 
-        // Reopen the app; ScanScreen consumes the pending acquisition and
-        // navigates to the results.
+    private fun reopenAppIntent(context: Context): PendingIntent {
         val intent = Intent(context, MainActivity::class.java)
             .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        val pendingIntent = PendingIntent.getActivity(
+        return PendingIntent.getActivity(
             context, 0, intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+    }
 
+    private fun postFinishedNotification(context: Context, analyzed: Boolean) {
+        val manager = ensureAcquisitionChannel(context) ?: return
+        // Reopen the app; ScanScreen consumes the pending acquisition and
+        // navigates to the results.
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_bugbane_zoom)
             .setContentTitle(context.getString(R.string.notification_acquisition_complete_title))
@@ -185,7 +246,26 @@ object AcquisitionProgressTracker {
                     else R.string.notification_acquisition_complete_text
                 )
             )
-            .setContentIntent(pendingIntent)
+            .setContentIntent(reopenAppIntent(context))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun postFailedNotification(context: Context, failed: List<String>) {
+        val manager = ensureAcquisitionChannel(context) ?: return
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bugbane_zoom)
+            .setContentTitle(context.getString(R.string.notification_acquisition_failed_title))
+            .setContentText(
+                context.getString(
+                    R.string.notification_acquisition_failed_text,
+                    failed.joinToString(", "),
+                )
+            )
+            .setContentIntent(reopenAppIntent(context))
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .build()

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/SlideshowManager.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/SlideshowManager.kt
@@ -94,4 +94,7 @@ object Keys {
 
     // Skips the "Get Started" page after the first onboarding flow
     const val KEY_HAS_SEEN_HOMEPAGE = "has_seen_homepage"
+
+    // Skips the beta warning countdown after the user has acknowledged it once
+    const val KEY_BETA_WARNING_ACKNOWLEDGED = "beta_warning_acknowledged"
 }

--- a/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
@@ -42,27 +42,31 @@ private const val TAG = "AcquisitionRunner"
  * to be implemented.
  */
 class AcquisitionRunner(
-    private val modules: List<Module> = listOf(
-        Env(),
-        Dumpsys(),
-        Files(),
-        Bugreport(),
-        Logs(),
-        Logcat(),
-        GetProp(),
-        Mounts(),
-        Packages(),
-        Processes(),
-        RootBinaries(),
-        Services(),
-        Settings(),
-        SELinux(),
-        Temp()
-    )
+    private val modules: List<Module> = DEFAULT_MODULES
 ) {
 
     companion object {
         const val ACQUISITION_KEY_ALIAS = "bugbane.acquisition.kek"
+
+        val DEFAULT_MODULES: List<Module> = listOf(
+            Env(),
+            Dumpsys(),
+            Files(),
+            Bugreport(),
+            Logs(),
+            Logcat(),
+            GetProp(),
+            Mounts(),
+            Packages(),
+            Processes(),
+            RootBinaries(),
+            Services(),
+            Settings(),
+            SELinux(),
+            Temp()
+        )
+
+        val MODULE_NAMES: List<String> = DEFAULT_MODULES.map { it.name }
 
         fun acquisitionKeyVault(): AndroidKeystoreKeyVault =
             AndroidKeystoreKeyVault.getOrCreateKeyVault(ACQUISITION_KEY_ALIAS, StrongBoxPolicy.PREFER)
@@ -74,7 +78,7 @@ class AcquisitionRunner(
     interface ProgressListener {
         fun onModuleStart(name: String, completed: Int, total: Int)
         fun onModuleProgress(name: String, bytes: Long)
-        fun onModuleComplete(name: String, completed: Int, total: Int)
+        fun onModuleComplete(name: String, completed: Int, total: Int, success: Boolean)
         fun isCancelled(): Boolean
         fun onFinished(cancelled: Boolean, output: File?)
     }
@@ -157,15 +161,17 @@ class AcquisitionRunner(
                 }
                 Log.i(TAG, "Running module ${module.name}")
                 listener?.onModuleStart(module.name, completedCount, total)
+                var success = true
                 try {
                     module.run(context, manager, writer, progressCb)
                     Log.i(TAG, "Module ${module.name} finished")
                 } catch (t: Throwable) {
+                    success = false
                     Log.e(TAG, "Module ${module.name} failed", t)
                     // TODO: display error message to the user
                 }
                 completedCount++
-                listener?.onModuleComplete(module.name, completedCount, total)
+                listener?.onModuleComplete(module.name, completedCount, total, success)
             }
 
             val completed = Instant.now()

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -62,9 +62,7 @@
     <string name="acquisitions_delete">Eliminar</string>
     <string name="acquisitions_delete_confirm_title">Eliminar Adquisición</string>
     <string name="acquisitions_delete_confirm_message">¿Seguro que desea eliminar %1$s? Esta acción no puede ser deshecha.</string>
-    <string name="acquisitions_delete_message">Eliminando %1$s…</string>
     <string name="acquisitions_deleted_message">%1$s eliminado</string>
-    <string name="acquisitions_undo">Deshacer</string>
     <string name="acquisitions_empty_message">Sin adquisiciones aún. Realice una para verla aquí.</string>
     <string name="acquisitions_rename_invalid">Nombre no válido</string>
     <string name="acquisitions_rename_failed">No es capaz de renombrar adquisición</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -60,9 +60,7 @@
     <string name="acquisitions_delete">Elimina</string>
     <string name="acquisitions_delete_confirm_title">Elimina acquisizione</string>
     <string name="acquisitions_delete_confirm_message">Sei sicuro di voler eliminare %1$s? Questa azione non può essere annullata.</string>
-    <string name="acquisitions_delete_message">Eliminazione di %1$s…</string>
     <string name="acquisitions_deleted_message">%1$s eliminato</string>
-    <string name="acquisitions_undo">Annulla</string>
     <string name="acquisitions_empty_message">Nessuna acquisizione presente. Effettuane una per vederla qui.</string>
     <string name="acquisitions_rename_invalid">Nome non valido</string>
     <string name="acquisitions_rename_failed">Impossibile rinominare l\'acquisizione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -38,6 +38,8 @@
     <string name="scan_cancelling_button">Annullamento...</string>
     <string name="scan_module_running">Esecuzione di %1$s: %2$s</string>
     <string name="scan_module_completed">Completato %1$s: %2$s</string>
+    <string name="scan_acquisition_failed_message">Attenzione: L\'acquisizione è incompleta.\nPuoi trovarla nella scheda Acquisizioni.\nModuli falliti: %1$s</string>
+    <string name="scan_acquisition_failed_rescan">Acquisisci nuovamente</string>
     <string name="beta_warning_title">Avviso Versione Beta</string>
     <string name="beta_warning_message">Questa è una versione Beta. Installala e testala su un telefono di riserva, NON su quello che usi quotidianamente. Procedi solo se hai compreso i rischi.</string>
     <string name="beta_warning_quit">Esci dall\'app</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -62,9 +62,7 @@
     <string name="acquisitions_delete">Удалить</string>
     <string name="acquisitions_delete_confirm_title">Удалить сбор данных</string>
     <string name="acquisitions_delete_confirm_message">Вы уверены, что хотите удалить %1$s? Это действие нельзя отменить.</string>
-    <string name="acquisitions_delete_message">Удаление %1$s…</string>
     <string name="acquisitions_deleted_message">%1$s удалён</string>
-    <string name="acquisitions_undo">Отменить</string>
     <string name="acquisitions_empty_message">Ещё нет сборов данных. Выполните сбор, чтобы увидеть его здесь.</string>
     <string name="acquisitions_rename_invalid">Некорректное имя</string>
     <string name="acquisitions_rename_failed">Не удалось переименовать сбор данных</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -62,9 +62,7 @@
     <string name="acquisitions_delete">நீக்கு</string>
     <string name="acquisitions_delete_confirm_title">கையகப்படுத்துதலை நீக்கு</string>
     <string name="acquisitions_delete_confirm_message">%1$sஐ நிச்சயமாக நீக்க விரும்புகிறீர்களா? இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.</string>
-    <string name="acquisitions_delete_message">%1$sஐ நீக்குகிறது…</string>
     <string name="acquisitions_deleted_message">%1$s நீக்கப்பட்டது</string>
-    <string name="acquisitions_undo">செயல்தவிர்</string>
     <string name="acquisitions_empty_message">இன்னும் கையகப்படுத்தல் இல்லை. அதை இங்கே பார்க்க ஒன்றைச் செய்யவும்.</string>
     <string name="acquisitions_rename_invalid">தவறான பெயர்</string>
     <string name="acquisitions_rename_failed">கையகப்படுத்துதலை மறுபெயரிட முடியவில்லை</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="scan_cancelling_button">Cancelling...</string>
     <string name="scan_module_running">Running %1$s: %2$s</string>
     <string name="scan_module_completed">Completed %1$s: %2$s</string>
+    <string name="scan_acquisition_failed_message">Warning: Acquisition is incomplete.\nYou can find it in the Acquisitions screen.\nFailed modules: %1$s</string>
+    <string name="scan_acquisition_failed_rescan">Perform another acquisition</string>
 
     <string name="beta_warning_title">Beta Version Warning</string>
     <string name="beta_warning_message">This is a Beta version. Install and test it on a spare phone, NOT on your everyday device. Only proceed if you understand the risks.</string>
@@ -169,6 +171,8 @@
     <string name="notification_acquisition_complete_title">Acquisition complete</string>
     <string name="notification_acquisition_complete_text">Tap to view the results</string>
     <string name="notification_acquisition_complete_analyzed_text">Analysis finished. Tap to view the results</string>
+    <string name="notification_acquisition_failed_title">Acquisition failed</string>
+    <string name="notification_acquisition_failed_text">Failed modules: %1$s</string>
 
     <!-- MVT strings -->
     <string name="mvt_ioc_title">Indicators of Compromise found</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,9 +91,7 @@
     <string name="acquisitions_delete">Delete</string>
     <string name="acquisitions_delete_confirm_title">Delete Acquisition</string>
     <string name="acquisitions_delete_confirm_message">Are you sure you want to delete %1$s? This action cannot be undone.</string>
-    <string name="acquisitions_delete_message">Deleting %1$s…</string>
     <string name="acquisitions_deleted_message">%1$s deleted</string>
-    <string name="acquisitions_undo">Undo</string>
     <string name="acquisitions_empty_message">No acquisitions yet. Perform one to see it here.</string>
     <string name="acquisitions_rename_invalid">Invalid name</string>
     <string name="acquisitions_rename_failed">Unable to rename acquisition</string>


### PR DESCRIPTION
This PR updates the Scan UI.
IMHO there are still UI/UX things that can be improved but this is ok for a first public beta.

Also, the beta countdown is prompted only on the first acquisition (maybe we should put a "Beta" badges somewhere to make it recognizable it's a beta?)
And finally, this PR gracefully handles modules that fail. (maybe we should store in the acquisition.zip.age the information about what module failed, androidqf stores the full CLI log)