### PR TITLE
Guard acquisitions against running out of storage

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/ScanScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -74,7 +75,7 @@ private fun ScanModuleCard(
                     text = formatModuleDisplayName(name),
                     style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
                 )
-                if (status != ModuleScanStatus.Waiting) {
+                if (status != ModuleScanStatus.Waiting && status != ModuleScanStatus.Skipped) {
                     Text(
                         text = " ${Utils.formatBytes(bytes)}",
                         style = MaterialTheme.typography.bodyLarge.copy(fontStyle = FontStyle.Italic),
@@ -104,6 +105,12 @@ private fun ModuleStatusIcon(status: ModuleScanStatus) {
             imageVector = Icons.Default.Close,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(22.dp),
+        )
+        ModuleScanStatus.Skipped -> Icon(
+            imageVector = Icons.Default.Remove,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
             modifier = Modifier.size(22.dp),
         )
         ModuleScanStatus.Waiting -> Spacer(modifier = Modifier.size(22.dp))
@@ -159,12 +166,14 @@ fun ScanScreen() {
     val totalModules = AcquisitionProgressTracker.totalModules.collectAsStateWithLifecycle()
     val pendingAcquisition = AcquisitionProgressTracker.pendingAcquisition.collectAsStateWithLifecycle()
     val failedModules = AcquisitionProgressTracker.failedModules.collectAsStateWithLifecycle()
+    val skippedForSpace = AcquisitionProgressTracker.skippedForSpace.collectAsStateWithLifecycle()
     val showDisableDialog = AcquisitionProgressTracker.showDisableReminder.collectAsStateWithLifecycle()
 
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val isScanning = adbState.value == AdbState.ConnectedAcquiring || adbState.value == AdbState.Cancelling
     val failed = failedModules.value
-    val showProgressUi = isScanning || failed != null
+    val skipped = skippedForSpace.value
+    val showProgressUi = isScanning || failed != null || skipped != null
 
     fun startAcquisition() {
         AcquisitionProgressTracker.start(context, adbManager, File(context.filesDir, "acquisitions"))
@@ -285,6 +294,37 @@ fun ScanScreen() {
                     ) {
                         Text(
                             text = stringResource(R.string.scan_acquisition_failed_rescan),
+                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                        )
+                    }
+                } else if (skipped != null) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer
+                        ),
+                        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.scan_acquisition_low_space_message,
+                                skipped.joinToString(", ") { formatModuleDisplayName(it) },
+                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Button(
+                        onClick = { AcquisitionProgressTracker.dismissSkippedForSpace() },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.scan_acquisition_low_space_dismiss),
                             style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
                         )
                     }

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/AcquisitionProgressTracker.kt
@@ -51,6 +51,7 @@ object AcquisitionProgressTracker {
         Running,
         Completed,
         Error,
+        Skipped,
     }
 
     data class ModuleProgress(
@@ -79,6 +80,10 @@ object AcquisitionProgressTracker {
     private val _failedModules = MutableStateFlow<List<String>?>(null)
     val failedModules: StateFlow<List<String>?> = _failedModules.asStateFlow()
 
+    /** Set when the last acquisition ran low on storage, until the UI dismisses it. */
+    private val _skippedForSpace = MutableStateFlow<List<String>?>(null)
+    val skippedForSpace: StateFlow<List<String>?> = _skippedForSpace.asStateFlow()
+
     /** True after a successful acquisition until the user dismisses the reminder. */
     private val _showDisableReminder = MutableStateFlow(false)
     val showDisableReminder: StateFlow<Boolean> = _showDisableReminder.asStateFlow()
@@ -96,6 +101,7 @@ object AcquisitionProgressTracker {
         _totalModules.value = AcquisitionRunner.MODULE_NAMES.size
         _pendingAcquisition.value = null
         _failedModules.value = null
+        _skippedForSpace.value = null
 
         adbManager.runQuickForensics(baseDir, object : AcquisitionRunner.ProgressListener {
             override fun onModuleStart(name: String, completed: Int, total: Int) {
@@ -136,6 +142,12 @@ object AcquisitionProgressTracker {
                 }
             }
 
+            override fun onModuleSkipped(name: String) {
+                _modules.update { list ->
+                    list.map { if (it.name == name) it.copy(status = ModuleScanStatus.Skipped) else it }
+                }
+            }
+
             override fun isCancelled(): Boolean = adbManager.isQuickForensicsCancelled
 
             override fun onFinished(cancelled: Boolean, output: File?) {
@@ -143,14 +155,16 @@ object AcquisitionProgressTracker {
                 val failed = _modules.value
                     .filter { it.status == ModuleScanStatus.Error }
                     .map { it.name }
-                if (failed.isNotEmpty()) {
-                    Log.w(TAG, "Acquisition finished with failed modules: $failed")
-                    _failedModules.value = failed
-                } else {
-                    _pendingAcquisition.value = output
+                val skipped = _modules.value
+                    .filter { it.status == ModuleScanStatus.Skipped }
+                    .map { it.name }
+                when {
+                    skipped.isNotEmpty() -> _skippedForSpace.value = skipped
+                    failed.isNotEmpty() -> _failedModules.value = failed
+                    else -> _pendingAcquisition.value = output
                 }
                 _showDisableReminder.value = true
-                autoAnalyze(appContext, output, failed)
+                autoAnalyze(appContext, output, failed, skipped)
             }
         })
     }
@@ -160,7 +174,12 @@ object AcquisitionProgressTracker {
      * background the completion notification is deferred until the analysis
      * is done, so tapping it lands on the results.
      */
-    private fun autoAnalyze(context: Context, acquisitionDir: File, failed: List<String>) {
+    private fun autoAnalyze(
+        context: Context,
+        acquisitionDir: File,
+        failed: List<String>,
+        skipped: List<String>,
+    ) {
         _analyzing.value = acquisitionDir
         analysisScope.launch {
             var analyzed = false
@@ -173,10 +192,10 @@ object AcquisitionProgressTracker {
                 _analyzing.value = null
             }
             if (!isAppInForeground()) {
-                if (failed.isNotEmpty()) {
-                    postFailedNotification(context, failed)
-                } else {
-                    postFinishedNotification(context, analyzed)
+                when {
+                    skipped.isNotEmpty() -> postLowSpaceNotification(context)
+                    failed.isNotEmpty() -> postFailedNotification(context, failed)
+                    else -> postFinishedNotification(context, analyzed)
                 }
             } else {
                 Log.d(TAG, "Skipping completion notification; app is in the foreground")
@@ -196,6 +215,10 @@ object AcquisitionProgressTracker {
 
     fun dismissFailedModules() {
         _failedModules.value = null
+    }
+
+    fun dismissSkippedForSpace() {
+        _skippedForSpace.value = null
     }
 
     private fun isAppInForeground(): Boolean {
@@ -267,6 +290,19 @@ object AcquisitionProgressTracker {
                     failed.joinToString(", "),
                 )
             )
+            .setContentIntent(reopenAppIntent(context))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        postAcquisitionNotification(context, notification)
+    }
+
+    private fun postLowSpaceNotification(context: Context) {
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_bugbane_zoom)
+            .setContentTitle(context.getString(R.string.notification_acquisition_low_space_title))
+            .setContentText(context.getString(R.string.notification_acquisition_low_space_text))
             .setContentIntent(reopenAppIntent(context))
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
@@ -49,12 +49,11 @@ class AcquisitionRunner(
     companion object {
         const val ACQUISITION_KEY_ALIAS = "bugbane.acquisition.kek"
 
-        // The two space-hungry modules run last, so low storage only ever costs
+        // The space-hungry modules run last, so low storage only ever costs
         // them and never the smaller high-value modules.
         val DEFAULT_MODULES: List<Module> = listOf(
             Env(),
             Dumpsys(),
-            Files(),
             Logs(),
             Logcat(),
             GetProp(),
@@ -65,7 +64,10 @@ class AcquisitionRunner(
             Settings(),
             SELinux(),
             Temp(),
-            // Large and poorly compressible; skipped first under low storage.
+            // Large; skipped first under low storage. The whole-filesystem
+            // listing can be big, and Bugreport/Packages are also poorly
+            // compressible.
+            Files(),
             Bugreport(),
             Packages(),
         )
@@ -151,13 +153,17 @@ class AcquisitionRunner(
         val writer = EncryptedAcquisitionWriter(acquisitionDir, vault)
 
         var cancelled = false
-        writer.use {
+        try {
             for (module in modules) {
                 if (listener?.isCancelled() == true) {
                     Log.i(TAG, "Acquisition cancelled before module ${module.name}")
                     cancelled = true
                     break
                 }
+                // Re-check free space at each boundary so a disk that was
+                // already full at the start, or filled by another app between
+                // modules, trips before we write anything.
+                writer.refreshOutOfSpace()
                 // Once out of space, skip this and every remaining module.
                 if (writer.outOfSpace) {
                     listener?.onModuleSkipped(module.name)
@@ -196,6 +202,14 @@ class AcquisitionRunner(
             val completed = Instant.now()
             index = if (cancelled) index.markAsCancelled(completed) else index.markAsComplete(completed)
             writer.writeIndex(index)
+        } catch (io: IOException) {
+            // Finalizing hit the disk despite the reserve. Keep whatever was
+            // collected and still report finished so the UI leaves the scanning
+            // state instead of hanging.
+            Log.e(TAG, "Failed to finalize acquisition", io)
+        } finally {
+            runCatching { writer.close() }
+                .onFailure { Log.e(TAG, "Failed to close acquisition archive", it) }
         }
 
         Log.i(TAG, "Acquisition finished in ${acquisitionDir.absolutePath}")

--- a/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/AcquisitionRunner.kt
@@ -26,6 +26,7 @@ import org.osservatorionessuno.qf.modules.Temp
 import org.osservatorionessuno.cadb.AdbShell
 import org.osservatorionessuno.qf.storage.AcquisitionIndex
 import org.osservatorionessuno.qf.storage.EncryptedAcquisitionWriter
+import org.osservatorionessuno.qf.storage.InsufficientStorageException
 import org.osservatorionessuno.qf.crypto.AndroidKeystoreKeyVault
 import org.osservatorionessuno.qf.crypto.AndroidKeystoreKeyVault.StrongBoxPolicy
 
@@ -48,22 +49,25 @@ class AcquisitionRunner(
     companion object {
         const val ACQUISITION_KEY_ALIAS = "bugbane.acquisition.kek"
 
+        // The two space-hungry modules run last, so low storage only ever costs
+        // them and never the smaller high-value modules.
         val DEFAULT_MODULES: List<Module> = listOf(
             Env(),
             Dumpsys(),
             Files(),
-            Bugreport(),
             Logs(),
             Logcat(),
             GetProp(),
             Mounts(),
-            Packages(),
             Processes(),
             RootBinaries(),
             Services(),
             Settings(),
             SELinux(),
-            Temp()
+            Temp(),
+            // Large and poorly compressible; skipped first under low storage.
+            Bugreport(),
+            Packages(),
         )
 
         val MODULE_NAMES: List<String> = DEFAULT_MODULES.map { it.name }
@@ -79,6 +83,8 @@ class AcquisitionRunner(
         fun onModuleStart(name: String, completed: Int, total: Int)
         fun onModuleProgress(name: String, bytes: Long)
         fun onModuleComplete(name: String, completed: Int, total: Int, success: Boolean)
+        /** A module skipped because storage ran low. */
+        fun onModuleSkipped(name: String) {}
         fun isCancelled(): Boolean
         fun onFinished(cancelled: Boolean, output: File?)
     }
@@ -152,6 +158,11 @@ class AcquisitionRunner(
                     cancelled = true
                     break
                 }
+                // Once out of space, skip this and every remaining module.
+                if (writer.outOfSpace) {
+                    listener?.onModuleSkipped(module.name)
+                    continue
+                }
 
                 var moduleBytes = 0L
                 val progressCb: (Long) -> Unit = { delta ->
@@ -165,25 +176,29 @@ class AcquisitionRunner(
                 try {
                     module.run(context, manager, writer, progressCb)
                     Log.i(TAG, "Module ${module.name} finished")
+                } catch (ise: InsufficientStorageException) {
+                    Log.w(TAG, "Module ${module.name} hit the storage reserve")
                 } catch (t: Throwable) {
                     success = false
                     Log.e(TAG, "Module ${module.name} failed", t)
                     // TODO: display error message to the user
+                }
+                // The latched guard, not the throw, is authoritative (modules may swallow it).
+                if (writer.outOfSpace) {
+                    Log.w(TAG, "Skipping ${module.name}: out of space")
+                    listener?.onModuleSkipped(module.name)
+                    continue
                 }
                 completedCount++
                 listener?.onModuleComplete(module.name, completedCount, total, success)
             }
 
             val completed = Instant.now()
-            index = if (cancelled) {
-                index.markAsCancelled(completed)
-            } else {
-                index.markAsComplete(completed)
-            }
+            index = if (cancelled) index.markAsCancelled(completed) else index.markAsComplete(completed)
             writer.writeIndex(index)
         }
 
-        Log.i(TAG, "Acquisition complete in ${acquisitionDir.absolutePath}")
+        Log.i(TAG, "Acquisition finished in ${acquisitionDir.absolutePath}")
         listener?.onFinished(cancelled, acquisitionDir)
         return acquisitionDir
     }

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/DigestingOutputStream.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/DigestingOutputStream.kt
@@ -10,6 +10,7 @@ import java.security.MessageDigest
  */
 class DigestingOutputStream(
     private val delegate: OutputStream,
+    private val guard: FreeSpaceGuard? = null,
     private val onClosed: ((sha256Hex: String) -> Unit)? = null,
 ) : OutputStream() {
     private val digest = MessageDigest.getInstance("SHA-256")
@@ -20,6 +21,7 @@ class DigestingOutputStream(
 
     @Throws(IOException::class)
     override fun write(b: Int) {
+        guard?.record(1)
         digest.update(b.toByte())
         delegate.write(b)
         bytesWritten++
@@ -27,6 +29,7 @@ class DigestingOutputStream(
 
     @Throws(IOException::class)
     override fun write(b: ByteArray, off: Int, len: Int) {
+        guard?.record(len)
         digest.update(b, off, len)
         delegate.write(b, off, len)
         bytesWritten += len

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
@@ -24,12 +24,17 @@ const val ARCHIVE_FILE: String = "acquisition.age"
 class EncryptedAcquisitionWriter(
     private val acquisitionDir: File,
     vault: KeyVault,
+    reserveBytes: Long = ACQUISITION_FREE_SPACE_RESERVE_BYTES,
 ) : ArtifactSink {
     private val writer = AgeZipArchiveWriter(FileOutputStream(File(acquisitionDir, ARCHIVE_FILE)), vault)
     private val writtenPaths = mutableSetOf<String>()
     private var indexWritten = false
     private val hashManifest = ByteArrayOutputStream()
     private var hashManifestArchived = false
+    private val guard = FreeSpaceGuard(reserveBytes) { availableAcquisitionBytes(acquisitionDir) }
+
+    /** True once a write hit the free-space reserve. */
+    val outOfSpace: Boolean get() = guard.tripped
 
     override fun openArtifact(path: String, modifiedTime: Long?): OutputStream {
         check(!hashManifestArchived) { "hash manifest already written" }
@@ -37,8 +42,11 @@ class EncryptedAcquisitionWriter(
         if (isReservedArtifact(name) || !writtenPaths.add(name)) {
             throw IOException("Artifact already exists: $path")
         }
-        return DigestingOutputStream(writer.putEntry(name, modifiedTime)) { sha256 ->
-            hashManifest.write(ArtifactHashes.formatLine(name, sha256).toByteArray(Charsets.UTF_8))
+        return DigestingOutputStream(writer.putEntry(name, modifiedTime), guard) { sha256 ->
+            // A truncated artifact's hash would be wrong; skip its manifest entry.
+            if (!guard.tripped) {
+                hashManifest.write(ArtifactHashes.formatLine(name, sha256).toByteArray(Charsets.UTF_8))
+            }
         }
     }
 

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/EncryptedAcquisition.kt
@@ -36,6 +36,9 @@ class EncryptedAcquisitionWriter(
     /** True once a write hit the free-space reserve. */
     val outOfSpace: Boolean get() = guard.tripped
 
+    /** Proactively samples free space, tripping the guard if it is already low. */
+    fun refreshOutOfSpace() = guard.checkNow()
+
     override fun openArtifact(path: String, modifiedTime: Long?): OutputStream {
         check(!hashManifestArchived) { "hash manifest already written" }
         val name = normalizeArtifactPath(path)

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/FreeSpaceGuard.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/FreeSpaceGuard.kt
@@ -20,7 +20,8 @@ class InsufficientStorageException(val availableBytes: Long, val reserveBytes: L
 
 /**
  * Latches [tripped] and throws once free space drops below [reserveBytes],
- * re-checking every [checkIntervalBytes] rather than per write. [availableBytes]
+ * re-checking every [checkIntervalBytes] rather than per write. [checkNow]
+ * forces an out-of-band sample (e.g. before a module starts). [availableBytes]
  * is injected for testing.
  */
 class FreeSpaceGuard(
@@ -35,17 +36,28 @@ class FreeSpaceGuard(
     private var bytesSinceCheck: Long = 0
 
     /** Records bytes about to be written; throws before the write once space runs low. */
+    @Synchronized
     fun record(len: Int) {
         if (tripped) throw exception()
         bytesSinceCheck += len
         if (bytesSinceCheck >= checkIntervalBytes) {
             bytesSinceCheck = 0
-            if (reserveBytes > 0 && availableBytes() < reserveBytes) {
+            if (isLow()) {
                 tripped = true
                 throw exception()
             }
         }
     }
+
+    /** Samples free space immediately and trips (without throwing) if it is already low. */
+    @Synchronized
+    fun checkNow() {
+        if (tripped) return
+        bytesSinceCheck = 0
+        if (isLow()) tripped = true
+    }
+
+    private fun isLow() = reserveBytes > 0 && availableBytes() < reserveBytes
 
     private fun exception() = InsufficientStorageException(availableBytes(), reserveBytes)
 }

--- a/app/src/main/java/org/osservatorionessuno/qf/storage/FreeSpaceGuard.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/storage/FreeSpaceGuard.kt
@@ -1,0 +1,51 @@
+package org.osservatorionessuno.qf.storage
+
+import android.os.StatFs
+import java.io.File
+import java.io.IOException
+
+/** Free space kept in reserve while writing, leaving room to finalize the archive. */
+const val ACQUISITION_FREE_SPACE_RESERVE_BYTES: Long = 5L * 1024 * 1024
+
+/** Free bytes on [dir]'s filesystem; MAX_VALUE if unreadable. */
+fun availableAcquisitionBytes(dir: File): Long =
+    try {
+        StatFs(dir.path).availableBytes
+    } catch (t: Throwable) {
+        Long.MAX_VALUE
+    }
+
+class InsufficientStorageException(val availableBytes: Long, val reserveBytes: Long) :
+    IOException("Free space $availableBytes below reserve $reserveBytes")
+
+/**
+ * Latches [tripped] and throws once free space drops below [reserveBytes],
+ * re-checking every [checkIntervalBytes] rather than per write. [availableBytes]
+ * is injected for testing.
+ */
+class FreeSpaceGuard(
+    private val reserveBytes: Long,
+    private val checkIntervalBytes: Long = 2L * 1024 * 1024,
+    private val availableBytes: () -> Long,
+) {
+    @Volatile
+    var tripped: Boolean = false
+        private set
+
+    private var bytesSinceCheck: Long = 0
+
+    /** Records bytes about to be written; throws before the write once space runs low. */
+    fun record(len: Int) {
+        if (tripped) throw exception()
+        bytesSinceCheck += len
+        if (bytesSinceCheck >= checkIntervalBytes) {
+            bytesSinceCheck = 0
+            if (reserveBytes > 0 && availableBytes() < reserveBytes) {
+                tripped = true
+                throw exception()
+            }
+        }
+    }
+
+    private fun exception() = InsufficientStorageException(availableBytes(), reserveBytes)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,8 @@
     <string name="scan_module_completed">Completed %1$s: %2$s</string>
     <string name="scan_acquisition_failed_message">Warning: Acquisition is incomplete.\nYou can find it in the Acquisitions screen.\nFailed modules: %1$s</string>
     <string name="scan_acquisition_failed_rescan">Perform another acquisition</string>
+    <string name="scan_acquisition_low_space_message">Skipped, not enough free space: %1$s</string>
+    <string name="scan_acquisition_low_space_dismiss">OK</string>
 
     <string name="beta_warning_title">Beta Version Warning</string>
     <string name="beta_warning_message">This is a beta version: use it at your own risk. Please report any bugs on GitHub.</string>
@@ -193,6 +195,8 @@
     <string name="notification_acquisition_complete_analyzed_text">Analysis finished. Tap to view the results</string>
     <string name="notification_acquisition_failed_title">Acquisition failed</string>
     <string name="notification_acquisition_failed_text">Failed modules: %1$s</string>
+    <string name="notification_acquisition_low_space_title">Storage ran low</string>
+    <string name="notification_acquisition_low_space_text">Some modules were skipped. Tap to view the results.</string>
 
     <!-- MVT strings -->
     <string name="mvt_ioc_title">Indicators of Compromise found</string>

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
@@ -1,6 +1,7 @@
 package org.osservatorionessuno.qf.storage
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -119,6 +120,17 @@ class EncryptedAcquisitionHashesTest {
             assertThrows<InsufficientStorageException> {
                 writer.useArtifact("big.bin") { it.write(ByteArray(4 * 1024 * 1024)) }
             }
+            assertTrue(writer.outOfSpace)
+        }
+    }
+
+    @Test
+    fun `refreshOutOfSpace trips before any write when the disk is already full`() {
+        val dir = tempDir()
+        // StatFs reports 0 free bytes in tests, so a full disk is detected upfront.
+        EncryptedAcquisitionWriter(dir, InMemoryKeyVault(), reserveBytes = 1).use { writer ->
+            assertFalse(writer.outOfSpace)
+            writer.refreshOutOfSpace()
             assertTrue(writer.outOfSpace)
         }
     }

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/EncryptedAcquisitionHashesTest.kt
@@ -71,7 +71,7 @@ class EncryptedAcquisitionHashesTest {
     @Test
     fun `hashes csv is reserved from module artifacts`() {
         val dir = tempDir()
-        EncryptedAcquisitionWriter(dir, InMemoryKeyVault()).use { writer ->
+        EncryptedAcquisitionWriter(dir, InMemoryKeyVault(), reserveBytes = 0).use { writer ->
             val error = runCatching { writer.openArtifact(HASHES_FILE) }.exceptionOrNull()
             assertNotNull(error)
             assertTrue(error!!.message!!.contains(HASHES_FILE))
@@ -88,7 +88,7 @@ class EncryptedAcquisitionHashesTest {
             // Hostile device filename: quoting must keep it one manifest record.
             "logs/innocent.txt,${"0".repeat(64)}\nbugreport.zip" to "boom".toByteArray(),
         )
-        EncryptedAcquisitionWriter(dir, vault).use { writer ->
+        EncryptedAcquisitionWriter(dir, vault, reserveBytes = 0).use { writer ->
             artifacts.forEach { (path, data) ->
                 writer.useArtifact(path) { it.write(data) }
             }
@@ -105,9 +105,21 @@ class EncryptedAcquisitionHashesTest {
     @Test
     fun `artifacts cannot be added after the manifest is archived`() {
         val dir = tempDir()
-        val writer = EncryptedAcquisitionWriter(dir, InMemoryKeyVault())
+        val writer = EncryptedAcquisitionWriter(dir, InMemoryKeyVault(), reserveBytes = 0)
         writer.useArtifact("getprop.txt") { it.write(1) }
         writer.close()
         assertThrows<IllegalStateException> { writer.openArtifact("late.txt") }
+    }
+
+    @Test
+    fun `writer stops writing once free space is below the reserve`() {
+        val dir = tempDir()
+        // The unit-test StatFs stub reports 0 free bytes, so any positive reserve trips.
+        EncryptedAcquisitionWriter(dir, InMemoryKeyVault(), reserveBytes = 1).use { writer ->
+            assertThrows<InsufficientStorageException> {
+                writer.useArtifact("big.bin") { it.write(ByteArray(4 * 1024 * 1024)) }
+            }
+            assertTrue(writer.outOfSpace)
+        }
     }
 }

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/FreeSpaceGuardTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/FreeSpaceGuardTest.kt
@@ -38,4 +38,26 @@ class FreeSpaceGuardTest {
         repeat(10) { guard.record(100) }
         assertFalse(guard.tripped)
     }
+
+    @Test
+    fun `checkNow trips when space is already below the reserve`() {
+        val guard = FreeSpaceGuard(reserve) { 50L }
+        guard.checkNow() // no bytes written yet, but the disk is already full
+        assertTrue(guard.tripped)
+        assertThrows<InsufficientStorageException> { guard.record(1) }
+    }
+
+    @Test
+    fun `checkNow leaves the guard untripped when space is sufficient`() {
+        val guard = FreeSpaceGuard(reserve) { 1_000L }
+        guard.checkNow()
+        assertFalse(guard.tripped)
+    }
+
+    @Test
+    fun `checkNow respects a disabled reserve`() {
+        val guard = FreeSpaceGuard(0L) { 0L }
+        guard.checkNow()
+        assertFalse(guard.tripped)
+    }
 }

--- a/app/src/test/java/org/osservatorionessuno/qf/storage/FreeSpaceGuardTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/storage/FreeSpaceGuardTest.kt
@@ -1,0 +1,41 @@
+package org.osservatorionessuno.qf.storage
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class FreeSpaceGuardTest {
+
+    private val reserve = 100L
+
+    @Test
+    fun `record only checks after the interval is crossed`() {
+        val guard = FreeSpaceGuard(reserve, checkIntervalBytes = 100L) { 50L }
+        guard.record(40) // below interval, no check
+        assertFalse(guard.tripped)
+        assertThrows<InsufficientStorageException> { guard.record(70) } // crosses 100 -> low
+        assertTrue(guard.tripped)
+    }
+
+    @Test
+    fun `record never trips while space stays above reserve`() {
+        val guard = FreeSpaceGuard(reserve, checkIntervalBytes = 10L) { 1_000L }
+        repeat(100) { guard.record(50) }
+        assertFalse(guard.tripped)
+    }
+
+    @Test
+    fun `once tripped every call throws immediately`() {
+        val guard = FreeSpaceGuard(reserve, checkIntervalBytes = 1L) { 10L }
+        assertThrows<InsufficientStorageException> { guard.record(1) }
+        assertThrows<InsufficientStorageException> { guard.record(1) }
+    }
+
+    @Test
+    fun `a non-positive reserve disables the guard`() {
+        val guard = FreeSpaceGuard(0L, checkIntervalBytes = 1L) { 0L }
+        repeat(10) { guard.record(100) }
+        assertFalse(guard.tripped)
+    }
+}


### PR DESCRIPTION
Acquisitions stream into internal storage with no size known ahead of time, so a full disk would surface as an ENOSPC mid-write, mislabelled as module failures and leaving the archive unfinalized.

Add a reserve-based FreeSpaceGuard: as artifacts stream, once free space would drop below the reserve it throws, and the writer leaves the entry out of the hash manifest. Modules are reordered so the small high-value ones run first and the large ones (Files, Bugreport, Packages) last; the runner then skips the module that ran out and every remaining one, keeps what was collected, and still writes the index and closes the archive. The result surfaces as a distinct "skipped, not enough free space" card and notification.

Addresses https://github.com/osservatorionessuno/bugbane/issues/85