### PR TITLE
No adb usb

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationManager.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationManager.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 private const val TAG = "ConfigurationManager"
 
 /**
- * Observe device configuration (developer mode, ADB, wireless debug) and emit values as StateFlow.
+ * Observe device configuration (developer mode, wireless debug) and emit values as StateFlow.
  * Also observes state of notification permissions, but those can't be subscribed to except in
  * a Composable function (with rememberPermissionState), so expose a handler to invoke from
  * Composable.
@@ -33,13 +33,10 @@ object ConfigurationManager {
     private val contentResolver get() = appContext.contentResolver
     private var developerOptsObserver: ContentObserver? = null
     private var wirelessDebugObserver: ContentObserver? = null
-    private var adbObserver: ContentObserver? = null
     private val _developerOptionsEnabled = MutableStateFlow(false)
     val developerOptionsEnabled: StateFlow<Boolean> = _developerOptionsEnabled.asStateFlow()
     private val _wirelessDebuggingEnabled = MutableStateFlow(false)
     val wirelessDebuggingEnabled: StateFlow<Boolean> = _wirelessDebuggingEnabled.asStateFlow()
-    private val _adbEnabled = MutableStateFlow(false)
-    val adbEnabled: StateFlow<Boolean> = _adbEnabled.asStateFlow()
     private val _notificationsEnabled = MutableStateFlow(false)
     val notificationsEnabled: StateFlow<Boolean> = _notificationsEnabled.asStateFlow()
 
@@ -79,16 +76,6 @@ object ConfigurationManager {
                 it
             )
         }
-
-        adbObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
-            override fun onChange(selfChange: Boolean) = adbObserverCheck()
-        }.also {
-            contentResolver.registerContentObserver(
-                Settings.Global.getUriFor(Settings.Global.ADB_ENABLED),
-                false,
-                it
-            )
-        }
     }
 
     // Run all checks
@@ -96,7 +83,6 @@ object ConfigurationManager {
         developerOptionsCheck()
         wirelessDebugCheck()
         notificationsCheck()
-        adbObserverCheck()
     }
 
     private fun developerOptionsCheck() {
@@ -118,14 +104,6 @@ object ConfigurationManager {
                 "adb_wifi_enabled", 0
             ) == 1
             _wirelessDebuggingEnabled.emit(enabled)
-        }
-    }
-
-    private fun adbObserverCheck() {
-        scope.launch {
-            val enabled =
-                Settings.Global.getInt(contentResolver, Settings.Global.ADB_ENABLED, 0) == 1
-            _adbEnabled.emit(enabled)
         }
     }
 
@@ -152,11 +130,6 @@ object ConfigurationManager {
         wirelessDebugObserver?.let {
             contentResolver.unregisterContentObserver(it)
             wirelessDebugObserver = null
-        }
-
-        adbObserver?.let {
-            contentResolver.unregisterContentObserver(it)
-            adbObserver = null
         }
 
         scope.cancel()

--- a/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/utils/ConfigurationViewModel.kt
@@ -82,7 +82,6 @@ class ConfigurationViewModel private constructor(
     data class SettingsState(
         val notificationsEnabled: Boolean,
         val developerOptionsEnabled: Boolean,
-        val adbEnabled: Boolean,
         val wirelessDebuggingEnabled: Boolean,
         val wifiConnected: Boolean
     )
@@ -96,11 +95,10 @@ class ConfigurationViewModel private constructor(
         viewModelScope.launch {
             val settingsFlow = combine(configurationManager.notificationsEnabled,
                 configurationManager.developerOptionsEnabled,
-                configurationManager.adbEnabled,
                 configurationManager.wirelessDebuggingEnabled,
                 wifiConnectivityMonitor.wifiState,
-            ) { notifications, devOpts, adbEnabled, wirelessDebug, wifiConnected ->
-                SettingsState(notifications, devOpts, adbEnabled, wirelessDebug, wifiConnected) }
+            ) { notifications, devOpts, wirelessDebug, wifiConnected ->
+                SettingsState(notifications, devOpts, wirelessDebug, wifiConnected) }
 
             combine(settingsFlow, adbManager.adbState, appManager.appProgress) { settings, adbState, appProgress ->
                 if (adbState == AdbState.RequisitesMissing) {
@@ -121,7 +119,6 @@ class ConfigurationViewModel private constructor(
                 checkState(
                     settings.notificationsEnabled,
                     settings.developerOptionsEnabled,
-                    settings.adbEnabled,
                     settings.wirelessDebuggingEnabled,
                     settings.wifiConnected,
                     adbState,
@@ -147,7 +144,6 @@ class ConfigurationViewModel private constructor(
     private fun checkState(
         notificationsEnabled: Boolean,
         developerOptionsEnabled: Boolean,
-        adbEnabled: Boolean,
         wirelessDebuggingEnabled: Boolean,
         isConnectedToWifi: Boolean,
         adbState: AdbState,
@@ -170,10 +166,11 @@ class ConfigurationViewModel private constructor(
         // the first acquisition, so this passes for them.
         if (!appProgress.hasAcquisitionProtection) return AppState.NeedAcquisitionProtection
 
-        // Wireless debug + usb debug were separate settings from Android 11-14
-        val needAdb = (!adbEnabled && Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-
-        if (wirelessDebuggingEnabled && !needAdb) {
+        // We require adb_wifi_enabled (Wireless Debugging), not Settings.Global.ADB_ENABLED
+        // (USB Debugging). Those are independent settings; wireless ADB does not depend on
+        // USB Debugging being on, including on Android 15+. An earlier check on ADB_ENABLED
+        // for API 35+ was removed for that reason.
+        if (wirelessDebuggingEnabled) {
             if (adbState == AdbState.ConnectedIdle && !appProgress.hasCompletedOnboarding) return AppState.AdbConnectedFinishOnboarding
             if (adbState == AdbState.ConnectedIdle) return AppState.AdbConnected
             if (adbState == AdbState.ConnectedAcquiring) return AppState.AdbScanning
@@ -188,10 +185,10 @@ class ConfigurationViewModel private constructor(
         // We need to go through some part of the pairing flow
         if (!isConnectedToWifi) return AppState.NeedWifi
         if (!developerOptionsEnabled) return AppState.NeedDeveloperOptions
-        if ((!wirelessDebuggingEnabled || needAdb) && !appProgress.hasCompletedOnboarding) return AppState.NeedWirelessDebuggingAndPair
+        if (!wirelessDebuggingEnabled && !appProgress.hasCompletedOnboarding) return AppState.NeedWirelessDebuggingAndPair
 
-        if ((!wirelessDebuggingEnabled || needAdb)) {
-            // Wireless adb or adb are off, but we've connected before. Enable wireless adb. Then autoconnect will be attempted.
+        if (!wirelessDebuggingEnabled) {
+            // Wireless adb is off, but we've connected before. Enable wireless adb. Then autoconnect will be attempted.
             Log.d(TAG, "Wireless adb is disabled, but we have previously connected successfully.")
             return AppState.NeedWirelessDebugging
         }


### PR DESCRIPTION
To be honest, I don't know why we coded the check on `Settings.Global.ADB_ENABLED` but turns out this is related ONLY to ADB USB, while `adb_wifi_enabled` is enough for WirelessADB.

I've tested this PR on:
- Android 11
- Android 13
- Android 16

Please test on more devices!