### PR TITLE
skip unreadable log targets instead of aborting the module

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/cadb/AdbConstants.kt
+++ b/app/src/main/java/org/osservatorionessuno/cadb/AdbConstants.kt
@@ -5,6 +5,7 @@ object AdbConstants {
     const val RECV = "RECV"
     const val LIST = "LIST"
     const val LIS2 = "LIS2"
+    const val STAT = "STAT"
 
     // Response commands
     const val DATA = "DATA"

--- a/app/src/main/java/org/osservatorionessuno/cadb/AdbSync.kt
+++ b/app/src/main/java/org/osservatorionessuno/cadb/AdbSync.kt
@@ -56,6 +56,31 @@ class AdbSync(
     }
 
     /**
+     * Whether adbd can stat [remotePath]. Uses the v1 STAT request, which reports
+     * mode 0 for missing and unreadable paths alike.
+     */
+    @Throws(IOException::class)
+    fun canStat(remotePath: String): Boolean {
+        manager.openStream(LocalServices.SYNC).use { stream ->
+            val out = stream.openOutputStream()
+            val input = stream.openInputStream()
+            sendSyncRequest(out, AdbConstants.STAT, remotePath)
+
+            val header = ByteArray(4)
+            readFully(input, header, 0, 4)
+            val response = String(header, StandardCharsets.US_ASCII)
+            if (response != AdbConstants.STAT) {
+                throw IOException("Unexpected stat response: $response (${cmdHex(header)})")
+            }
+            // mode (4), size (4), mtime (4) — little endian
+            val fields = ByteArray(12)
+            readFully(input, fields, 0, 12)
+            val mode = ByteBuffer.wrap(fields, 0, 4).order(ByteOrder.LITTLE_ENDIAN).int
+            return mode != 0
+        }
+    }
+
+    /**
      * List remote files in a directory.
      *
      * @param remoteDir Path on the device to list from.

--- a/app/src/main/java/org/osservatorionessuno/qf/modules/Logs.kt
+++ b/app/src/main/java/org/osservatorionessuno/qf/modules/Logs.kt
@@ -33,22 +33,28 @@ class Logs : Module {
     ) {
         val sync = AdbSync(manager, progress)
 
-        val result = runCatching {
-            for (target in targets) {
+        // Several targets are root-only on production devices: skip per target so one
+        // denied path cannot cost the readable ones.
+        for (target in targets) {
+            runCatching {
                 if (target.endsWith("/")) {
                     sync.pullFolder(target, writer, "logs")
                 } else {
+                    // Stat first: a failed pull would still commit an empty artifact entry.
+                    if (!sync.canStat(target)) {
+                        Log.w(TAG, "Skipping $target: missing or inaccessible")
+                        return@runCatching
+                    }
                     val name = target.substringAfterLast('/')
                     writer.useArtifact("logs/$name") { output ->
                         sync.pull(target, output)
                     }
                 }
+            }.onFailure {
+                // TODO: write this feedback to the acquisition report in some way
+                Log.e(TAG, "Failed to pull $target", it)
             }
-            Log.i(TAG, "Pulled logs")
         }
-        if (result.isFailure) {
-            // TODO: write this feedback to the acquisition report in some way
-            Log.e(TAG, "Failed to pull logs", result.exceptionOrNull())
-        }
+        Log.i(TAG, "Pulled logs")
     }
 }


### PR DESCRIPTION
Addresses https://github.com/osservatorionessuno/bugbane/issues/108

Some logs are readable in the emulator or elsewhere, depending on whether `adbd` runs with high privileges or not. We should try to gather the logs anyway, knowing it might fail. However, the failure should only affect the specific filename, and not the entire logs module.