### PR TITLE
name exports after the acquisition so they do not overwrite each other

### DIFF
--- a/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionDetailScreen.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/screens/AcquisitionDetailScreen.kt
@@ -45,7 +45,7 @@ import org.osservatorionessuno.bugbane.components.AcquisitionIdentityLostDialog
 import org.osservatorionessuno.bugbane.utils.AcquisitionRecovery
 import org.osservatorionessuno.bugbane.share.AcquisitionShareProvider
 import org.osservatorionessuno.bugbane.share.AcquisitionExport
-import org.osservatorionessuno.bugbane.share.EXPORT_FILE_NAME
+import org.osservatorionessuno.bugbane.share.exportFileName
 import org.osservatorionessuno.libmvt.common.AlertLevel
 import org.json.JSONObject
 import java.io.File
@@ -217,7 +217,7 @@ fun AcquisitionDetailScreen(acquisitionDir: File) {
             exportIdentity?.destroy()
             exportIdentity = identity
             passphrase = Utils.generatePassphrase()
-            exportLauncher.launch(EXPORT_FILE_NAME)
+            exportLauncher.launch(exportFileName(acquisitionDir))
         }
     }
 
@@ -231,7 +231,7 @@ fun AcquisitionDetailScreen(acquisitionDir: File) {
                 File(acquisitionDir, ARCHIVE_FILE),
                 identity,
                 pass,
-                EXPORT_FILE_NAME,
+                exportFileName(acquisitionDir),
             )
             val intent = Intent(Intent.ACTION_SEND).apply {
                 type = "application/octet-stream"
@@ -243,7 +243,7 @@ fun AcquisitionDetailScreen(acquisitionDir: File) {
                 // The read grant only reliably follows a URI in ClipData; EXTRA_STREAM
                 // alone isn't covered. Only the app the user picks receives the grant
                 // and the EXTRA_TEXT passphrase.
-                clipData = ClipData.newRawUri(EXPORT_FILE_NAME, uri)
+                clipData = ClipData.newRawUri(exportFileName(acquisitionDir), uri)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             context.startActivity(Intent.createChooser(intent, null))

--- a/app/src/main/java/org/osservatorionessuno/bugbane/share/AcquisitionExport.kt
+++ b/app/src/main/java/org/osservatorionessuno/bugbane/share/AcquisitionExport.kt
@@ -7,10 +7,13 @@ import java.io.File
 import java.io.OutputStream
 
 /**
- * File name presented for an exported/shared acquisition. The `.zip.age` suffix
- * reflects the payload: an age file whose plaintext is a ZIP (`age -d … | unzip`).
+ * File name presented for an exported/shared acquisition: `acquisition-<id>.zip.age`,
+ * where `<id>` is the first block of the acquisition UUID, so exports of different
+ * acquisitions don't overwrite each other. The `.zip.age` suffix reflects the
+ * payload: an age file whose plaintext is a ZIP (`age -d … | unzip`).
  */
-const val EXPORT_FILE_NAME: String = "acquisition.zip.age"
+fun exportFileName(acquisitionDir: File): String =
+    "acquisition-${acquisitionDir.name.substringBefore('-')}.zip.age"
 
 /**
  * Passphrase re-wrap of an at-rest acquisition archive: rewrites the ~200-byte


### PR DESCRIPTION
Implements https://github.com/osservatorionessuno/bugbane/issues/101, however instead of random it uses the acquisition uuid. Different acquisitions wouldn't overwrite each other,  but the same one would. I think it's slightly better not to clobber storage excessively with saves of the same thing.