### PR TITLE
Hold the age stream key in Secret

### DIFF
--- a/crypto/src/main/kotlin/org/osservatorionessuno/qf/crypto/SeekableArchive.kt
+++ b/crypto/src/main/kotlin/org/osservatorionessuno/qf/crypto/SeekableArchive.kt
@@ -34,7 +34,8 @@ internal class FileRandomAccess(file: File) : RandomAccessData {
  */
 class SeekableArchive(private val file: File, identities: List<AgeIdentity>) : Closeable {
     private val access = FileRandomAccess(file)
-    private val zip = ZipFile(AgePayloadChannel(AgePayload.open(access, identities)))
+    private val payload = AgePayload.open(access, identities)
+    private val zip = ZipFile(AgePayloadChannel(payload))
 
     fun names(): Set<String> {
         val out = LinkedHashSet<String>()
@@ -50,6 +51,7 @@ class SeekableArchive(private val file: File, identities: List<AgeIdentity>) : C
 
     override fun close() {
         zip.close()
+        payload.close()
         access.close()
     }
 }

--- a/crypto/src/main/kotlin/org/osservatorionessuno/qf/crypto/age/AgePayload.kt
+++ b/crypto/src/main/kotlin/org/osservatorionessuno/qf/crypto/age/AgePayload.kt
@@ -1,6 +1,7 @@
 package org.osservatorionessuno.qf.crypto.age
 
 import org.osservatorionessuno.qf.crypto.RandomAccessData
+import org.osservatorionessuno.qf.crypto.Secret
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 
@@ -13,14 +14,26 @@ import java.io.InputStream
  */
 class AgePayload private constructor(
     private val data: RandomAccessData,
-    private val streamKey: ByteArray,
+    streamKey: ByteArray,
     private val cipherStart: Long,
     private val numChunks: Long,
     private val lastCipherLen: Int,
     val length: Long,
-) {
+) : AutoCloseable {
+    // Off-heap; zeroed on close.
+    private val streamKey = Secret(streamKey)
     private var cachedIdx = -1L
     private var cached: ByteArray? = null
+    private var closed = false
+
+    /** Wipe the stream key and drop the cached chunk; idempotent. */
+    override fun close() {
+        if (closed) return
+        closed = true
+        cached = null
+        cachedIdx = -1L
+        streamKey.close()
+    }
 
     /** Read [len] decrypted bytes at plaintext offset [off]. */
     fun read(off: Long, len: Int): ByteArray {
@@ -54,6 +67,7 @@ class AgePayload private constructor(
     }
 
     private fun chunk(idx: Long): ByteArray {
+        check(!closed) { "age payload closed" }
         cached?.let { if (idx == cachedIdx) return it }
         val last = idx == numChunks - 1
         val clen = if (last) lastCipherLen else CIPHER_I
@@ -63,7 +77,7 @@ class AgePayload private constructor(
         // carries the last-flag, so a truncated payload fails to authenticate. Surface
         // any decrypt/auth failure as AgeFormatException, never a raw cipher exception.
         val pt = try {
-            AgePrimitives.chachaOpen(streamKey, streamNonce(idx, last), ct, 0, clen)
+            streamKey.withBytes { key -> AgePrimitives.chachaOpen(key, streamNonce(idx, last), ct, 0, clen) }
         } catch (e: Exception) {
             throw AgeFormatException("age payload chunk $idx failed to authenticate")
         }


### PR DESCRIPTION
AgePayload keeps its stream key off-heap in a Secret and wipes it on close; SeekableArchive closes the payload. Mostly just to consistently use the `Secret` class everywhere where there's some type of secrets management.