### PR TITLE
Add planted-detection integration tests per artifact module

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,13 +39,20 @@ jobs:
           unzip -q gradle-${GRADLE_VERSION}-bin.zip -d "$HOME/gradle"
           echo "$HOME/gradle/gradle-${GRADLE_VERSION}/bin" >> "$GITHUB_PATH"
 
-      - name: Build release APK
-        run: gradle --no-daemon assembleProductionRelease
+      - name: Build release APK + suspicious fixture APK
+        run: gradle --no-daemon assembleProductionRelease :fixtures:suspicious-apk:assembleDebug
 
       - uses: actions/upload-artifact@v4
         with:
           name: integration-apk
           path: app/build/outputs/apk/production/release/app-production-release.apk
+          compression-level: 0
+          retention-days: 3
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: integration-fixture-apk
+          path: fixtures/suspicious-apk/build/outputs/apk/debug/suspicious-apk-debug.apk
           compression-level: 0
           retention-days: 3
 
@@ -85,6 +92,10 @@ jobs:
         with:
           name: integration-apk
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: integration-fixture-apk
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -114,7 +125,7 @@ jobs:
           disable-animations: true
           emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -no-snapshot
-          script: ./integration/run.sh app-production-release.apk
+          script: ./integration/run.sh app-production-release.apk suspicious-apk-debug.apk
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/app/src/test/java/org/osservatorionessuno/qf/crypto/PlantedDetectionIntegrationTest.kt
+++ b/app/src/test/java/org/osservatorionessuno/qf/crypto/PlantedDetectionIntegrationTest.kt
@@ -1,0 +1,133 @@
+package org.osservatorionessuno.qf.crypto
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.osservatorionessuno.libmvt.android.ForensicRunner
+import org.osservatorionessuno.libmvt.android.parsers.CertificateParser
+import org.osservatorionessuno.libmvt.common.Artifact
+import org.osservatorionessuno.libmvt.common.GroupedDetection
+import org.osservatorionessuno.libmvt.common.Indicators
+import org.osservatorionessuno.libmvt.common.ReopenableInput
+import org.osservatorionessuno.libmvt.common.StringResolver
+import org.osservatorionessuno.qf.ArtifactProtobuf
+import org.osservatorionessuno.qf.crypto.age.X25519Identity
+import org.osservatorionessuno.qf.modules.Packages
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.Date
+import java.util.LinkedHashMap
+
+/**
+ * Plant a known-bad entry per artifact module, write it with bugbane's own writer,
+ * age-encrypt, decrypt and analyze with the real libMVT: the planted value must
+ * surface as a detection. Also the parity guard for the artifact-format migration.
+ */
+class PlantedDetectionIntegrationTest {
+
+    private val resolver = object : StringResolver {
+        override fun get(name: String): String = name
+    }
+
+    private val hash = "deadbeef".repeat(8) // 64-hex
+
+    // Encrypt [bytes] as [name], then decrypt + analyze it.
+    private fun analyze(name: String, bytes: ByteArray, indicators: Indicators = Indicators()): Map<String, Artifact> {
+        val id = X25519Identity.generate()
+        val archive = File.createTempFile("planted-", ".age").apply { deleteOnExit() }
+        ByteArrayOutputStream().also { out ->
+            AgeZipArchiveWriter(out, listOf(id.recipient())).use { writer ->
+                writer.putEntry(name).use { sink -> ByteArrayInputStream(bytes).use { it.copyTo(sink) } }
+            }
+            archive.writeBytes(out.toByteArray())
+        }
+        val result = LinkedHashMap<String, Artifact>()
+        AgeZipArchiveReader.forEachEntry(archive, listOf(id)) { entryName, _, open ->
+            if (!ForensicRunner.isAnalyzable(entryName)) return@forEachEntry
+            val runner = ForensicRunner(resolver).apply { setIndicators(indicators) }
+            result.putAll(runner.streamFileAnalysis(ReopenableInput.of(entryName) { open() }))
+        }
+        return result
+    }
+
+    // Every detection as "id|value|file", for substring assertions.
+    private fun detectionBlob(artifacts: Map<String, Artifact>): String =
+        GroupedDetection.fromArtifacts(artifacts).flatMap { group ->
+            group.detections.map { "${group.id}|${it.value}|${it.file ?: ""}" }
+        }.joinToString("\n")
+
+    // Indicators loaded from a temp iocs.json of STIX key -> value.
+    private fun indicatorsOf(vararg pairs: Pair<String, String>): Indicators {
+        val entry = JSONObject()
+        for ((key, value) in pairs) entry.put(key, JSONArray().put(value))
+        val root = JSONObject().put("indicators", JSONArray().put(entry))
+        val dir = Files.createTempDirectory("iocs").toFile().apply { deleteOnExit() }
+        File(dir, "iocs.json").writeText(root.toString())
+        return Indicators().apply { loadFromDirectory(dir) }
+    }
+
+    private fun bytes(write: (ByteArrayOutputStream) -> Unit): ByteArray =
+        ByteArrayOutputStream().also(write).toByteArray()
+
+    private fun packageFile(sha256: String = "", certs: List<CertificateParser.CertificateInfo> = emptyList()) =
+        Packages.PackageFile("/data/app/x/base.apk", "", "", "", sha256, "", false, certs, emptyList())
+
+    private fun cert(sha256: String) = CertificateParser.CertificateInfo(
+        "CN=Evil", "CN=Evil", Date(0), Date(0), "SHA256withRSA", 3, "1", false,
+        CertificateParser.Checksum("", "", sha256),
+    )
+
+    private fun pkg(name: String = "com.example.app", file: Packages.PackageFile? = null) =
+        Packages.Package(name = name, files = listOfNotNull(file))
+
+    @Test
+    fun `files - suspicious tmp path is detected`() {
+        val artifact = bytes {
+            ArtifactProtobuf.writeDelimitedFileRecord(it, "/data/local/tmp/evil.sh", null, "755", 128L, null, null)
+        }
+        val blob = detectionBlob(analyze("files.pb", artifact))
+        assertTrue(blob.contains("/data/local/tmp/evil.sh"), "expected suspicious-path detection; got:\n$blob")
+    }
+
+    @Test
+    fun `mounts - system partition mounted read-write is detected`() {
+        val artifact = bytes {
+            ArtifactProtobuf.writeDelimitedStringRecord(it, "/dev/block/dm-0 on /system type ext4 (rw,relatime)")
+        }
+        val blob = detectionBlob(analyze("mounts.pb", artifact))
+        assertTrue(blob.contains("/system"), "expected system-mount detection; got:\n$blob")
+    }
+
+    @Test
+    fun `root_binaries - known su binary is detected`() {
+        val artifact = bytes { ArtifactProtobuf.writeDelimitedStringRecord(it, "/system/xbin/su") }
+        val blob = detectionBlob(analyze("root_binaries.pb", artifact))
+        assertTrue(blob.contains("/system/xbin/su"), "expected root-binary detection; got:\n$blob")
+    }
+
+    @Test
+    fun `packages - app id IOC is detected`() {
+        val artifact = bytes { ArtifactProtobuf.writeDelimitedPackageRecord(it, pkg(name = "com.evil.spyware")) }
+        val blob = detectionBlob(analyze("packages.pb", artifact, indicatorsOf("app:id" to "com.evil.spyware")))
+        assertTrue(blob.contains("com.evil.spyware"), "expected app:id IOC match; got:\n$blob")
+    }
+
+    @Test
+    fun `packages - apk file hash IOC is detected`() {
+        val artifact = bytes { ArtifactProtobuf.writeDelimitedPackageRecord(it, pkg(file = packageFile(sha256 = hash))) }
+        val blob = detectionBlob(analyze("packages.pb", artifact, indicatorsOf("file:hashes.sha256" to hash)))
+        assertTrue(blob.contains(hash), "expected apk file-hash IOC match; got:\n$blob")
+    }
+
+    @Test
+    fun `packages - signing certificate hash IOC is detected`() {
+        val artifact = bytes {
+            ArtifactProtobuf.writeDelimitedPackageRecord(it, pkg(file = packageFile(certs = listOf(cert(hash)))))
+        }
+        val blob = detectionBlob(analyze("packages.pb", artifact, indicatorsOf("app:cert.sha256" to hash)))
+        assertTrue(blob.contains(hash), "expected signing-cert IOC match; got:\n$blob")
+    }
+}

--- a/fixtures/suspicious-apk/build.gradle.kts
+++ b/fixtures/suspicious-apk/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    alias(libs.plugins.android.application)
+}
+
+// Benign code-less APK whose manifest trips libMVT's suspicious heuristic (accessibility
+// service). The CI emulator installs it so the acquisition stages it (integration/run.sh).
+android {
+    namespace = "org.osservatorionessuno.fixture.suspicious"
+    compileSdk = 36
+    defaultConfig {
+        applicationId = "org.osservatorionessuno.fixture.suspicious"
+        minSdk = 30
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0"
+    }
+    // The accessibility service names no real class on purpose; don't fail lint on it.
+    lint { abortOnError = false }
+}

--- a/fixtures/suspicious-apk/src/main/AndroidManifest.xml
+++ b/fixtures/suspicious-apk/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Benign fixture: no code. The accessibility service + dangerous permissions make
+     libMVT's APKStaticAnalyzer return suspicious=true, so bugbane stages this APK. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <application android:label="suspicious-fixture">
+        <service
+            android:name=".AccessibilityCollector"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -7,7 +7,9 @@
 # so all evidence is captured before then via the EXIT trap). No `-e`: capture first.
 set -uo pipefail
 
-APK="${1:?usage: run.sh <apk>}"
+APK="${1:?usage: run.sh <apk> [suspicious-fixture-apk]}"
+FIXTURE="${2:-}"
+SUSPICIOUS_APPID=org.osservatorionessuno.fixture.suspicious
 DIR="$(cd "$(dirname "$0")" && pwd)"
 FLOWS="$DIR/maestro"
 ART="${INTEGRATION_ARTIFACTS:-$DIR/artifacts}"
@@ -45,6 +47,9 @@ adb shell settings put global hide_error_dialogs 1 || true
 adb shell settings put system notification_cooldown_enabled 0 || true
 adb shell settings put system notification_cooldown_all 0 || true
 adb install -r -g "$APK"
+# A benign "suspicious" APK (accessibility service): the acquisition's Packages module
+# must flag it and stage it into the archive, asserted host-side in verify_export.py.
+[ -n "$FIXTURE" ] && adb install -r -g "$FIXTURE"
 
 # Onboard + open the Settings pairing dialog (6-digit code left on screen).
 run_flow pair.yaml || exit 1
@@ -78,6 +83,6 @@ run_flow set-password.yaml || exit 1
 NAME="$(adb shell 'ls -t /sdcard/Download/' | tr -d '\r' | grep -m1 '\.zip\.age$')"
 if [ -z "$NAME" ]; then echo "NO EXPORT IN DOWNLOADS"; exit 1; fi
 adb pull "/sdcard/Download/$NAME" "$ART/$NAME"
-python3 "$DIR/verify_export.py" "$ART/$NAME" "$PASSPHRASE" || exit 1
+python3 "$DIR/verify_export.py" "$ART/$NAME" "$PASSPHRASE" ${FIXTURE:+"$SUSPICIOUS_APPID"} || exit 1
 
 echo "INTEGRATION E2E PASS"

--- a/integration/verify_export.py
+++ b/integration/verify_export.py
@@ -15,7 +15,7 @@ REQUIRED_ENTRIES = ["acquisition.json", "dumpsys.txt", "getprop.txt", "packages.
 MIN_BUGREPORT_BYTES = 100_000
 
 
-def verify(path, passphrase):
+def verify(path, passphrase, suspicious_appid=None):
     with open(path, "rb") as f:
         ciphertext = f.read()
     plaintext = pyrage.passphrase.decrypt(ciphertext, passphrase)
@@ -24,6 +24,13 @@ def verify(path, passphrase):
     missing = [e for e in REQUIRED_ENTRIES if e not in names]
     if missing:
         raise AssertionError("missing entries: %s (have: %s)" % (missing, names))
+    # The suspicious APK heuristic staged the fixture's APK into the archive.
+    if suspicious_appid:
+        staged = [n for n in names if n.startswith("apks/") and suspicious_appid in n]
+        if not staged:
+            apks = [n for n in names if n.startswith("apks/")]
+            raise AssertionError("suspicious APK %s not staged; apks/: %s" % (suspicious_appid, apks))
+        print("suspicious APK staged: %s" % staged, flush=True)
     index = json.loads(z.read("acquisition.json"))
     if not index.get("uuid"):
         raise AssertionError("acquisition.json has no uuid")
@@ -41,4 +48,4 @@ def verify(path, passphrase):
 
 
 if __name__ == "__main__":
-    verify(sys.argv[1], sys.argv[2])
+    verify(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else None)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ rootProject.name = "Bugbane"
 include(":app")
 include(":crypto")
 include(":lint-rules")
+include(":fixtures:suspicious-apk")
 
 // Project-wide default value is set to true, but can be overridden in "gradle.properties".
 val useLocalLibmvt = providers.gradleProperty("libmvtLocal")


### PR DESCRIPTION
Plant a known-bad entry for files, mounts, root_binaries and packages (app id, apk file hash, signing-cert hash), write it with bugbane's writer, age-encrypt, decrypt and analyze with libMVT; each planted value must surface as a detection.

To be used latr as a base to test end to end for libmvt parsing of bugbane artifacts.